### PR TITLE
Summarize

### DIFF
--- a/private/zo-shell.rkt
+++ b/private/zo-shell.rkt
@@ -35,8 +35,12 @@
 (define (init args)
   ;; (-> (listof string?) void?)
   (match args
-    [(vector fname) (init-from-filename fname)]
-    [_              (print-usage)]))
+    ['#()
+     (print-usage)]
+    [(vector fname)
+     (init-from-filename fname)]
+    [(vector fname args ...)
+     (find-all fname args)]))
 
 ;; --- Commands (could go in their own file)
 
@@ -362,7 +366,20 @@
 (define (print-usage)
   (displayln "Usage: zo-shell FILE.zo"))
 
-;; --- parsing
+;; --- misc
+
+(define (find-all name args)
+  ;; (-> string? (vectorof string?) void)
+  (print-info (format "Loading bytecode file '~a'..." name))
+  (call-with-input-file name
+    (lambda (port)
+      (print-info "Parsing bytecode...")
+      (define ctx (zo-parse port))
+      (print-info "Parsing complete! Searching...")
+      (for ([arg (in-list args)])
+        (printf "FIND '~a' : " arg)
+        (printf "~a results\n" (length (zo-find ctx arg))))
+      (displayln "All done!"))))
 
 ;; Split the string `raw` by whitespace and
 ;; return the second element of the split, if any.

--- a/private/zo-shell.rkt
+++ b/private/zo-shell.rkt
@@ -406,11 +406,8 @@
 
   ;; --- API
   ;; -- invalid args for init. read-line makes sure some message was printed.
-  (check-equal? (init '())                 (void))
-  (check-pred read-line in)
-  (check-equal? (init '(two args))         (void))
-  (check-pred read-line in)
-  (check-equal? (init '(more than 2 args)) (void))
+  ;; -- TODO more init tests
+  (check-equal? (init '#())                 (void))
   (check-pred read-line in)
 
   ;; --- command predicates

--- a/private/zo-transition.rkt
+++ b/private/zo-transition.rkt
@@ -184,7 +184,7 @@
   ;; (-> def-values? string? (or/c (listof zo?) zo? #f))
   (match field-name
     ["ids"
-     (def-values-ids z)]
+     (filter toplevel? (def-values-ids z))]
     ["rhs"
      (match (def-values-rhs z)
        [(or (? expr? rhs) (? seq? rhs) (? inline-variant? rhs))

--- a/scribblings/overview.scrbl
+++ b/scribblings/overview.scrbl
@@ -8,6 +8,8 @@
 @section{Quickstart}
 
 The main entry point is @tt{zordoz.rkt}.
+
+@subsection{Explorer}
 If you have a bytecode file ready, run
 
 @racketblock[racket zordoz.rkt FILE.zo]
@@ -29,6 +31,21 @@ At your service. Available commands:
   quit        Exit the interpreter
 ]
 
+@subsection{Quick Search}
+To search a bytecode file for occurrences of a certain zo struct, run
+@racketblock[racket zordoz.rkt FILE.zo STRUCT-NAME ...]
+
+the number of occurrences of each struct will be printed to the console.
+For example:
+@racketblock[
+$ racket zordoz.rkt private/compiled/zo-string_rkt.zo branch lam
+INFO: Loading bytecode file 'private/compiled/zo-string_rkt.zo'...
+INFO: Parsing bytecode...
+INFO: Parsing complete! Searching...
+FIND 'branch' : 427 results
+FIND 'lam' : 433 results
+All done! 
+]
 
 @section{Building}
 
@@ -52,7 +69,7 @@ or individually using:
 @racketblock[raco test FILE.rkt]
 
 
-@section{Manifesto}
+@section{Project Goals}
 
 The goal of this project is to help explore Racket bytecode in any useful way.
 

--- a/scribblings/repl.scrbl
+++ b/scribblings/repl.scrbl
@@ -8,7 +8,11 @@ The REPL is a simple, interactive way to explore bytecode files.
 It is implemented in the file @tt{zo-shell.rkt}, which exports a single function:
 
 @defproc[(init [args (vectorof string?)]) void?]{
-  Accepts a @tt{vector} of command-line arguments, parses the first argument as a bytecode file, then starts a REPL session using the output of calling @hyperlink["http://docs.racket-lang.org/raco/decompile.html#%28def._%28%28lib._compiler%2Fzo-parse..rkt%29._zo-parse%29%29"]{zo-parse} on this file.
+  Accepts a @tt{vector} of command-line arguments.
+  @itemlist[
+    @item{If given exactly one argument, starts a REPL session using the output of calling @hyperlink["http://docs.racket-lang.org/raco/decompile.html#%28def._%28%28lib._compiler%2Fzo-parse..rkt%29._zo-parse%29%29"]{zo-parse} on this file.}
+    @item{If given more than one argument, parses the first argument as a bytecode file and the rest as strings. Searches the parsed bytecode file for structs matching the strings using @code{zo-find}.}
+  ]
 }
 
 This document is a users' guide for the REPL.
@@ -258,7 +262,7 @@ zo> info
   else : #f
 ]
 
-And if we doa @secref{jump}, we return to the search results.
+And if we do a @secref{jump}, we return to the search results.
 
 @racketblock[
 zo> jump


### PR DESCRIPTION
Before, the only command was `./zordoz FILE.zo`. Now, you can call `./zordoz FILE.zo STRUCT-NAME ...` to immediately count occurrences of `STRUCT-NAME` in the bytecode `FILE.zo`.