### PR TITLE
Typed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,10 @@ exe:
 	raco exe zordoz.rkt
 
 test:
+	echo "-- Testing untyped code"
 	raco test private/zo-find.rkt
 	raco test private/zo-shell.rkt
 	raco test private/zo-string.rkt
 	raco test private/zo-transition.rkt
+	echo "-- Verifying that typed struct definitions compile"
+	raco make typed/typed-zo-structs.rkt

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Zordoz
 
 This is an explorer for Racket .zo files.
 
-Tested to work on Racket `v6.2.900.11`.
+Tested to work on Racket `v6.2.900.15`.
 For compatibility with older versions, see the [v6.2](https://github.com/bennn/zordoz/tree/v6.2) and [v6.1](https://github.com/bennn/zordoz/tree/v6.1) branches of this repo.
 (Note that installing through `raco` will choose the version matching your Racket install.)
 
@@ -35,6 +35,9 @@ Depending on how you installed, you can either:
 1. `./zordoz FILE.zo`
 2. `raco zordoz FILE.zo`
 
+Passing the `-t` option uses typed racket code.
+Beware, the typed racket version is up to 5x slower than untyped because of contracts with the `compiler/zo-lib` structs.
+
 The REPL accepts the following commands:
 
 - `alst` prints all command aliases; for example, the repl treats the words 'alst' and 'aliases' the same way
@@ -52,16 +55,18 @@ Check the [guide](http://bennn.github.io/zordoz) for a summary.
 
 ### Quick Search
 
-Passing the names of AST nodes on the command line immediately counts their occurrences in the source.
-For example, running:
+Running:
 
 ```
-./zordoz FILE.zo branch lam closure
+./zordoz -f branch -f lam -f closure FILE.zo
 ```
 
 Will count and print the number of times the zo structs [branch](http://docs.racket-lang.org/raco/decompile.html#%28def._%28%28lib._compiler%2Fzo-structs..rkt%29._branch%29%29) [lam](http://docs.racket-lang.org/raco/decompile.html#%28def._%28%28lib._compiler%2Fzo-structs..rkt%29._lam%29%29) and [closure](http://docs.racket-lang.org/raco/decompile.html#%28def._%28%28lib._compiler%2Fzo-structs..rkt%29._closure%29%29) appear.
-(This may take a while, depending on the size of the bytecode file.)
+This may take a while, depending on the size of the bytecode file.
+You can limit the search depth by passing a natural number with the `-l` flag.
+
 See the [decompilation guide](http://docs.racket-lang.org/raco/decompile.html#%28mod-path._compiler%2Fzo-structs%29) for a list of all zo struct names.
+
 
 Background
 ----------

--- a/scribblings/api.scrbl
+++ b/scribblings/api.scrbl
@@ -6,6 +6,8 @@
 @defmodule[zordoz]
 
 These functions support the REPL, but may be useful in more general settings.
+Import them with `(require zordoz)`.
+Typed variants of the same functions are available with `(require zordoz/typed)`.
 
 
 @section{String Representations}

--- a/typed/main.rkt
+++ b/typed/main.rkt
@@ -1,0 +1,28 @@
+#lang typed/racket/base
+
+(require compiler/zo-structs
+         zordoz/typed/private/zo-string
+         zordoz/typed/private/zo-transition
+         zordoz/typed/private/zo-find
+         zordoz/typed/private/zo-shell)
+
+(provide
+  result result? result-zo result-path
+  ;; TODO
+
+  zo->string
+  ;; TODO
+
+  zo->spec
+  ;; TODO
+
+  zo-transition
+  ;; TODO
+
+  zo-find
+  ;; TODO
+
+  zo->shell
+  ;; TODO
+
+)

--- a/typed/private/zo-find.rkt
+++ b/typed/private/zo-find.rkt
@@ -1,0 +1,108 @@
+#lang typed/racket/base
+
+;; Simple utility for searching zo structs.
+;; Explores the current struct's fields recursively for a exact string match.
+
+(provide
+ ;; (-> zo String [#:limit (U Natural #f)] (Listof result))
+ ;; Search a struct recursively for member zo-structs matching a string.
+ zo-find
+ ;; Search result: a zo-struct and the path to reach it
+ (struct-out result))
+
+(require (only-in racket/list empty?)
+         (only-in racket/string string-split string-trim)
+         zordoz/typed/typed-zo-structs
+         zordoz/typed/private/zo-transition
+         zordoz/typed/private/zo-string
+         racket/match)
+
+;; -----------------------------------------------------------------------------
+
+;; --- API functions
+
+(struct result ([zo : zo]
+                [path : (Listof zo)])
+        #:transparent)
+
+(: append-all (All (A) (-> (Listof (Listof A)) (Listof A))))
+(define (append-all xss)
+  (cond [(empty? xss) '()]
+        [else (append (car xss) (append-all (cdr xss)))]))
+
+;; Searches a zo-struct `z` recursively for member zo-structs matching the `s`.
+;; Terminates after at most `#:limit` recursive calls.
+;; Return a list of 'result' structs.
+(: zo-find (-> zo String [#:limit (U Natural #f)] (Listof result)))
+(define (zo-find z str #:limit [lim #f])
+  ;; (-> zo? string? (listof result?))
+  (define-values (_ children) (parse-zo z))
+  (append-all (for/list : (Listof (Listof result)) ([z* : zo children])
+                        (zo-find-aux z* '() str 1 lim '()))))
+
+;; ;; --- private functions
+
+;; Check if `str` is one of the known looping zo-structs.
+;; 2015-01-23: So far as I know, only closures may loop.
+;; 2015-07-29: New macro expander => scope and multi-scope can loop
+(: may-loop? (-> String Boolean))
+(define (may-loop? str)
+  (if (member str '("closure" "multi-scope" "scope"))
+      #t #f))
+
+;; Recursive helper for `zo-find`.
+;; Add the current struct to the results, if it matches.
+;; Check struct members for matches unless the search has reached its limit.
+(: zo-find-aux (-> zo (Listof zo) String Natural (U Natural #f) (Listof String) (Listof result)))
+(define (zo-find-aux z hist str i lim seen)
+  (define-values (title children) (parse-zo z))
+  (define zstr (format "~a" z))
+  (: results (Listof result))
+  (define results
+    (cond
+     [(and lim (<= lim i))
+      '()]
+     ;; Terminate search if we're seeing a node for the second time
+     [(and (may-loop? title) (member zstr seen))
+      '()]
+     [else
+      ;; Remember current node if we might see it again.
+      (: seen* (Listof String))
+      (define seen* (if (may-loop? title) (cons zstr seen) seen))
+      (: hist* (Listof zo))
+      (define hist* (cons z hist))
+      (append-all (for/list : (Listof (Listof result)) ([z* : zo children])
+                              (zo-find-aux z* hist* str (add1 i) lim seen*)))]))
+  (if (and (string=? str title) (not (member z seen)))
+      (cons (result z hist) results)
+      results))
+
+;; Return the name of the zo `z` and a list of its child zo structs.
+;; Uses `zo-string.rkt` to parse a raw struct.
+(: parse-zo (-> zo (values String (Listof zo))))
+(define (parse-zo z)
+  (: z-spec Spec)
+  (define z-spec     (zo->spec z))
+  (: title String)
+  (define title      (car z-spec))
+  (: child-strs (Listof String))
+  (define child-strs (for/list : (Listof String) ([pair : (Pair String (-> (U String Spec))) (cdr z-spec)])
+                               (car pair)))
+  (values title (get-children z child-strs)))
+
+;; Given a zo `z` and list of possible field names `strs`, return the list
+;; of zo-structs obtained by looking up each name in `strs` in the struct `z`.
+;; Relies on `zo-transition.rkt` to do the lookup.
+(: get-children (-> zo (Listof String) (Listof zo)))
+(define (get-children z strs)
+  (match strs
+    ['() '()]
+    [(cons hd tl)
+     (define-values (r* success*) (zo-transition z hd))
+     (: r (U zo (Listof zo)))
+     (define r r*)
+     (: success? Boolean)
+     (define success? success*)
+     (cond [(not success?) (get-children z tl)]
+           [(list? r)      (append (filter zo? r) (get-children z tl))]
+           [(zo?   r)      (cons r (get-children z tl))])]))

--- a/typed/private/zo-shell.rkt
+++ b/typed/private/zo-shell.rkt
@@ -1,0 +1,486 @@
+#lang typed/racket/base
+
+;; Command-line UI for exploring decompiled bytecode.
+;; (Use `raco make` to generate bytecode)
+
+(provide
+ filename->shell
+ ;; (-> String Void)
+ ;; Start a repl using the zo file `filename`
+
+ zo->shell
+ ;; Start a repl using the zo struct
+
+ find-all
+ ;; (->* [String (Listof String)] [#:limit (U Natural #f)] Void)
+ ;; (find-all zo arg* #:lim n)
+ ;; Searches the bytecode file `zo` for all zo-structs named by the list `arg*`
+ ;;  and prints the number of matches.
+ ;; If `#:limit` is not false, recursive searches are terminated at depth `n`.
+ ;;
+ ;; For example, if `arg*` is '("branch" "lam"), then the result will be the number
+ ;; of zo structs in the decompiled output that match the `branch?` or `lam?` predicates.
+
+ print-usage
+ ;; (-> Void)
+ ;; Display terms-of-use
+)
+
+(require (only-in racket/string string-split string-join string-trim)
+         (only-in zordoz/typed/private/zo-find zo-find result result? result-zo result-path)
+         (only-in zordoz/typed/private/zo-string zo->string zo->spec)
+         (only-in zordoz/typed/private/zo-transition zo-transition)
+         zordoz/typed/typed-zo-structs
+         racket/match
+)
+(require/typed compiler/zo-parse
+  [zo-parse (-> Input-Port zo)])
+
+;; -----------------------------------------------------------------------------
+
+;; --- constants & contracts
+
+;; when set, print extra debugging information
+(define DEBUG   #f)
+;; For aesthetic purposes
+(define VERSION 1.0)
+(define VNAME   "vortex")
+(define-type Context (U zo (Listof zo) (Listof result)))
+(define-type History (Listof Context))
+(define-type History* (Listof History))
+
+;; --- API functions
+
+;; Entry point to the REPL, expects command-line arguments passed as a list.
+;; In the future, there may be more entry points.
+(: init (-> (Vectorof String) Void))
+(define (init args)
+  (match args
+    ['#()
+     (print-usage)]
+    ;; Catch --help flag, and any others
+    [(? has-any-flags?) (print-usage)]
+    [(vector fname)
+     (filename->shell fname)]
+    [(vector fname args ...)
+     (find-all fname args)]))
+
+;; --- Commands (could go in their own file)
+
+(struct command (
+  [name : String]
+  [num-args : Natural]
+  [aliases : (Listof String)]
+  [help-msg : String])
+#:transparent)
+(define-type Command command)
+
+(define ALST (command "alst"
+                      0
+                      (list "a" "alias" "aliases")
+                      "Print command aliases"))
+(define BACK (command "back"
+                      0
+                      (list "b" "up" "u" ".." "../" "cd .." "cd ../")
+                      "Move up to the previous context"))
+(define DIVE (command "dive"
+                      1
+                      (list "d" "cd" "next" "step")
+                      "Step into struct field ARG"))
+(define FIND (command "find"
+                      1
+                      (list "f" "query" "search" "look")
+                      "Search the current subtree for structs with the name ARG"))
+(define HELP (command "help"
+                      0
+                      (list "h" "-h" "--h" "-help" "--help")
+                      "Print this message"))
+(define INFO (command "info"
+                      0
+                      (list "i" "ls" "print" "p" "show")
+                      "Show information about current context"))
+(define JUMP (command "jump"
+                      0
+                      (list "j" "warp" "top")
+                      "Revert to last saved position"))
+(define SAVE (command "save"
+                      0
+                      (list "mark")
+                      "Save the current context as jump target"))
+(define QUIT (command "quit"
+                      0
+                      (list "q" "exit" "leave" "bye")
+                      "Exit the interpreter"))
+(define COMMANDS
+  (list ALST BACK DIVE FIND HELP INFO JUMP SAVE QUIT))
+
+(: cmd? (-> Command (-> String Boolean)))
+(define ((cmd? c) str)
+  (define splt (string-split str))
+  (or
+   ;; Special cases
+   (and (string=? "back" (command-name c))
+        (member? str (list "cd .." "cd ../")))
+   ;; Everything else
+   (and
+    ;; Has the right number of arguments
+    (= (sub1 (length splt))
+       (command-num-args c))
+    ;; First word matches command name (or an alias)
+    (or (string=? (car splt) (command-name c))
+        (member?   (car splt) (command-aliases c))))))
+
+;; --- REPL
+
+;; Start REPL from a filename
+(: filename->shell (-> String Void))
+(define (filename->shell name)
+  (print-info (format "Loading bytecode file '~a'..." name))
+  (call-with-input-file name
+    (lambda ([port : Input-Port])
+      (print-info "Parsing bytecode...")
+      (define ctx  (zo-parse port))
+      (print-info "Parsing complete!")
+      (print-welcome)
+      ((repl ctx '() '()) '()))))
+
+(: zo->shell (-> zo Void))
+(define (zo->shell z)
+  ;; (-> zo? void?)
+  (print-welcome)
+  ((repl z '() '()) '()))
+
+;; Split a path like "cd ../BLAH/.." into a list of commands "cd ..; cd BLAH; cd .."
+(: split-cd (-> (Listof String) (Listof String)))
+(define (split-cd cmd*)
+  ;; (-> (listof string?) (listof string?))
+  (match cmd*
+    ['() '()]
+    [(cons cd-cmd rest)
+     #:when (starts-with? cd-cmd "cd ")
+     ;; Split "cd " commands by "/"
+     (append
+      (map (lambda ([x : String]) (string-append "cd " x)) (string-split (substring cd-cmd 3) "/"))
+      (split-cd rest))]
+    [(cons cmd rest)
+     ;; Leave other commands alone
+     (cons cmd (split-cd rest))]))
+
+;; The REPL loop. Process a command using context `ctx` and history `hist`.
+(: repl (-> Context History (Listof History) (-> (Listof String) Void)))
+(define ((repl ctx hist pre-hist) cmd*)
+  (when DEBUG (print-history hist))
+  (match cmd*
+    ['()
+     (print-prompt ctx)
+     (define ln (read-line))
+     (if (eof-object? ln)
+         (error 'zo-shell:repl "EOF: you have penetrated me")
+         ((repl ctx hist pre-hist)
+          (split-cd (for/list : (Listof String)
+                                ([str (in-list (string-split ln ";"))])
+                      (string-trim str)))))]
+    [(cons (? (cmd? ALST) raw) cmd*)
+     (print-alias) ((repl ctx hist pre-hist) cmd*)]
+    [(cons (? (cmd? BACK) raw) cmd*)
+     ((call-with-values (lambda () (back raw ctx hist pre-hist)) repl) cmd*)]
+    [(cons (? (cmd? DIVE) raw) cmd*)
+     ((call-with-values (lambda () (dive raw ctx hist pre-hist)) repl) cmd*)]
+    [(cons (? (cmd? FIND) raw) cmd*)
+     ((call-with-values (lambda () (find raw ctx hist pre-hist)) repl) cmd*)]
+    [(cons (? (cmd? HELP) raw) cmd*)
+     (begin (print-help) ((repl ctx hist pre-hist) cmd*))]
+    [(cons (? (cmd? INFO) raw) cmd*)
+     (begin (print-context ctx) ((repl ctx hist pre-hist) cmd*))]
+    [(cons (? (cmd? JUMP) raw) cmd*)
+     ((call-with-values (lambda () (jump raw ctx hist pre-hist)) repl) cmd*)]
+    [(cons (? (cmd? SAVE) raw) cmd*)
+     ((call-with-values (lambda () (save raw ctx hist pre-hist)) repl) cmd*)]
+    [(cons (? (cmd? QUIT) raw) cmd*)
+     (print-goodbye)]
+    [(cons raw cmd*)
+     (begin (print-unknown raw) ((repl ctx hist pre-hist) cmd*))]))
+
+;; --- command implementations
+
+;; 2015-01-23: Warn about possible-unexpected behavior
+(define BACK-WARNING
+  (string-append
+   "BACK removing most recent 'save' mark. "
+   "Be sure to save if you want to continue exploring search result."))
+
+;; Step back to a previous context, if any, and reduce the history.
+;; Try popping from `hist`, fall back to list-of-histories `pre-hist`.
+(: back (-> String Context History History* (Values Context History History*)))
+(define (back raw ctx hist pre-hist)
+  (match (list hist pre-hist)
+    [(list '() '())
+     ;; Nothing to pop from
+     (print-unknown raw)
+     (values ctx hist pre-hist)]
+    [(list '() _)
+     ;; Pop from pre-history
+     (displayln BACK-WARNING)
+     (define-values (hist* pre-hist*) (pop pre-hist))
+     (back raw ctx hist* pre-hist*)]
+    [_
+     (define-values (ctx* hist*) (pop hist))
+     (values ctx* hist* pre-hist)]))
+
+;; Search context `ctx` for a new context matching string `raw`.
+;; Push `ctx` onto the stack `hist` on success.
+(: dive (-> String Context History History* (Values Context History History*)))
+(define (dive raw ctx hist pre-hist)
+  (define arg (split-snd raw))
+  (define-values (ctx* hist*)
+    (cond
+     [(not arg)
+      ;; Failed to parse argument,
+      (print-unknown raw)
+      (values ctx hist)]
+     [(list? ctx)
+      ;; Context is a list, try accessing by index
+      (dive-list ctx hist arg)]
+     [(zo?   ctx)
+      ;; Context is a zo, try looking up field
+      (dive-zo   ctx hist arg)]
+     [else
+      ;; Should never happen! REPL controls the context.
+      (error 'zo-shell:dive (format "Invalid context '~a'" ctx))]))
+  ;; Return pre-hist unchanged
+  (values ctx* hist* pre-hist))
+
+;; Parse the string `arg` to an integer n.
+;; If n is within the bounds of the list `ctx`,
+;; push `ctx` onto the stack `hist` and return the n-th element of `ctx`.
+;; Otherwise, return `ctx` and `hist` unchanged.
+(: dive-list (-> (U (Listof result) (Listof zo)) History String (Values Context History)))
+(define (dive-list ctx hist arg)
+  (define index (string->number arg))
+  (cond [(or (not index) (not (index? index)) (< index 0) (>= index (length ctx)))
+         ;; Index out of bounds, or not a number. Cannot dive.
+         (print-unknown (format "dive ~a" arg))
+         (values ctx hist)]
+        [else
+         ;; Select from list,
+         (define res (list-ref ctx index))
+         ;; If list elements are search results, current `hist` can be safely ignored.
+         (if (result? res)
+             (values (result-zo res) (result-path res))
+             (values res             (push hist ctx)))]))
+
+;; Use the string `field` to access a field in the zo struct `ctx`.
+;; If the field exists and denotes another zo struct, return that
+;; struct and push `ctx` on to the stack `hist`.
+;; Otherwise, return `ctx` and `hist` unchanged.
+(: dive-zo (-> zo History String (Values Context History)))
+(define (dive-zo ctx hist field)
+  (define-values (ctx* success?) (zo-transition ctx field))
+  (cond
+   [success?
+    (values ctx* (push hist ctx))]
+   [else
+    (print-unknown (format "dive ~a" field))
+    (values ctx hist)]))
+
+;; Parse argument, then search for & save results.
+(: find (-> String Context History History* (Values Context History History*)))
+(define (find raw ctx hist pre-hist)
+  (define arg (split-snd raw))
+  (cond [(and arg (zo? ctx))
+         (define results (zo-find ctx arg))
+         (printf "FIND returned ~a results\n" (length results))
+         (match results
+           ['()
+            ;; No results, don't make a save mark
+            (values ctx hist pre-hist)]
+           [_
+            ;; Success! Show the results and save them, to allow jumps
+            (printf "FIND automatically saving context\n")
+            (print-context results)
+            (save "" results (push hist ctx) pre-hist)])]
+        [else
+         (print-unknown raw)
+         (values ctx hist pre-hist)]))
+
+;; Jump back to a previously-saved location, if any.
+(: jump (-> String Context History History* (Values Context History History*)))
+(define (jump raw ctx hist pre-hist)
+  (match pre-hist
+    ['()
+     ;; Nothing to jump to
+     (print-unknown raw)
+     (values ctx hist pre-hist)]
+    [_
+     (define-values (hist* pre-hist*) (pop pre-hist))
+     (back raw ctx hist* pre-hist*)]))
+
+;; Save the current context and history to the pre-history
+;; For now, erases current history.
+(: save (-> String Context History History* (Values Context History History*)))
+(define (save raw ctx hist pre-hist)
+  (values ctx '() (push pre-hist (push hist ctx))))
+
+;; --- history manipulation
+
+;; Add the context `ctx` to the stack `hist`.
+(: push (All (A) (-> (Listof A) A (Listof A))))
+(define (push hist ctx)
+  (cons ctx hist))
+
+;; Remove the top context from the stack `hist`.
+;; Return the popped value and tail of `hist`.
+;; Callers must avoid calling `pop` on empty stacks.
+(: pop (All (A) (-> (Listof A) (values A (Listof A)))))
+(define (pop hist)
+  (values (car hist) (cdr hist)))
+
+;; --- print
+
+(define (print-alias)
+  ;; (-> void?)
+  (displayln "At your service. Command aliases:")
+  (displayln (string-join
+    (for/list : (Listof String) ([cmd : Command COMMANDS])
+      (format "  ~a        ~a"
+              (command-name cmd)
+              (string-join (command-aliases cmd))))))
+  (newline))
+
+;; Print a history object.
+(: print-history (-> History Void))
+(define (print-history hist)
+  ;; (-> history? void?)
+  (printf "History is: ~a\n" hist))
+
+;; Print a help message for the REPL.
+(define (print-help)
+  ;; (-> void?)
+  (displayln "At your service. Available commands:")
+  (displayln
+   (string-join
+    (for/list : (Listof String) ([cmd COMMANDS])
+      (format "  ~a~a    ~a"
+              (command-name cmd)
+              (if (= 1 (command-num-args cmd)) " ARG" "    ") ;; hack
+              (command-help-msg cmd)))
+    "\n")))
+
+;; Print a context.
+(: print-context (-> Context Void))
+(define (print-context ctx)
+  ;; (-> context? void?)
+  (match ctx
+    [(? zo?)
+     (displayln (zo->string ctx))]
+    ['()
+     (displayln "'()")]
+    [(cons x _)
+     (define z (if (result? x) (result-zo x) x))
+     (printf "~a[~a]\n"
+             (zo->string z #:deep? #f)
+             (length ctx))]
+    [_
+     (error 'zo-shell:info (format "Unknown context '~a'"  ctx))]))
+
+;; Print an error message (after receiving an undefined/invalid command).
+(: print-unknown (-> String Void))
+(define (print-unknown raw)
+  (printf "'~a' not permitted.\n" raw))
+
+;; Print a goodbye message (when the user exits the REPL).
+(define (print-goodbye)
+  (printf "Ascending to second-level meditation. Goodbye.\n\n"))
+
+;; Print a debugging message.
+(: print-debug (-> String Void))
+(define (print-debug str)
+  ;; (-> string? void?)
+  (printf "DEBUG: ~a\n" str))
+
+;; Print a welcome message (when the user enters the REPL).
+(define (print-welcome)
+  (display
+   (format "\033[1;34m--- Welcome to the .zo shell, version ~a '~a' ---\033[0;0m\n" VERSION VNAME)))
+
+;; Print the REPL prompt.
+(: print-prompt (-> Context Void))
+(define (print-prompt ctx)
+  (define tag (cond [(list? ctx) (format "[~a]" (length ctx))]
+                    [(zo? ctx)   (format "(~a)" (car (zo->spec ctx)))]
+                    [else ""]))
+  (display (string-append tag " \033[1;32mzo> \033[0;0m")))
+
+;; Print an informative message.
+(: print-info (-> String Void))
+(define (print-info str)
+  ;; (-> string? void?)
+  (printf "INFO: ~a\n" str))
+
+;; Print a warning.
+(: print-warn (-> String Void))
+(define (print-warn str)
+  ;; (-> string? void?)
+  (printf "WARN: ~a\n" str))
+
+;; Print an error message.
+(define (print-error str)
+  ;; (-> string? void?)
+  (printf "ERROR: ~a\n" str))
+
+;; Print usage information.
+(define USAGE
+  "Usage: zo-shell <OPTIONS> FILE.zo")
+(define (print-usage)
+  (displayln USAGE))
+
+;; --- misc
+
+(: member? (-> String (Listof String) Boolean))
+(define (member? s str*)
+  (if (member s str*) #t #f))
+
+;; Check if second arg is a prefix of the first
+(: starts-with? (-> String String Boolean))
+(define (starts-with? str prefix)
+  ;; (-> string? string? boolean?)
+  (and (<= (string-length prefix)
+           (string-length str))
+       (for/and ([c1 (in-string str)]
+                 [c2 (in-string prefix)])
+         (char=? c1 c2))))
+
+(: find-all (->* [String (Listof String)] [#:limit (U Natural #f)] Void))
+(define (find-all name args #:limit [lim #f])
+  (print-info (format "Loading bytecode file '~a'..." name))
+  (call-with-input-file name
+    (lambda ([port : Input-Port])
+      (print-info "Parsing bytecode...")
+      (define ctx (zo-parse port))
+      (print-info "Parsing complete! Searching...")
+      (for ([arg (in-list args)])
+        (printf "FIND '~a' : " arg)
+        (printf "~a results\n" (length (zo-find ctx arg #:limit lim))))
+      (displayln "All done!"))))
+
+;; Split the string `raw` by whitespace and
+;; return the second element of the split, if any.
+;; Otherwise return `#f`.
+(: split-snd (-> String (U #f String)))
+(define (split-snd raw)
+  (define splt (string-split raw))
+  (match splt
+    [(list _ x)       x]
+    [(list _ x ys ...) (print-warn (format "Ignoring extra arguments: '~a'" ys))
+                       x]
+    [_ #f]))
+
+;; True if the vector contains any command-line flags.
+;; All flags begin with a hyphen, -
+(: has-any-flags? (-> (Vectorof String) Boolean))
+(define (has-any-flags? v)
+  ;; (-> (vectorof string) boolean?)
+  (for/or ([str (in-vector v)])
+    (and (< 0 (string-length str))
+         (eq? #\- (string-ref str 0)))))
+

--- a/typed/private/zo-string.rkt
+++ b/typed/private/zo-string.rkt
@@ -1,0 +1,879 @@
+#lang typed/racket/base
+
+;; Convert a zo struct to a more readable string representation.
+
+;; Uses predicates to guess which struct we have, then convert the known
+;; fields to strings.
+;; Printing a field recursively is potentially expensive,
+;; so we wrap the computation in a thunk.
+;; The macro `lcons` makes thunk creation a little prettier.
+;; The function `format-spec` forces these thunks.
+
+;; Documentation for zo structs is online:
+;; http://docs.racket-lang.org/raco/decompile.html
+
+(provide
+ ;; (: zo->string (->* (zo) (#:deep? Boolean) String))
+ ;; Return a string representation of a zo struct
+ zo->string
+ ;; (: zo->spec (-> zo Spec))
+ ;; Return a list-of-strings representation of a zo struct.
+ ;; The structure of the list mirrors the structure of the original zo struct.
+ zo->spec
+ Spec)
+
+;; --- string specifications
+
+(require racket/match
+         (only-in racket/list   empty?)
+         (only-in racket/string string-join)
+         (for-syntax racket/base racket/syntax)
+         zordoz/typed/typed-zo-structs)
+
+(require/typed racket/base
+  [srcloc->string (-> (U #f srcloc) String)])
+
+;; -----------------------------------------------------------------------------
+
+;; --- API functions
+
+;; Convert any zo struct to a spec/c representation.
+(: zo->spec (-> zo Spec))
+(define
+  (zo->spec z)
+  (: z* (U Spec #f))
+  (define z* (try-spec z))
+  (if z*
+      z*
+      (error (format "Cannot format unknown struct ~e" z))))
+
+;; Convert any zo struct to a string.
+;; First builds a spec, then forces the thunks in that spec to build a string.
+;; If `deep` is `#f`, only formats the name of the struct `z`.
+(: zo->string (->* (zo) (#:deep? Boolean) String))
+(define
+  (zo->string z #:deep? [deep? #t])
+  (format-spec deep? (zo->spec z)))
+
+;; --- syntax: lazy cons to delay evaluation of tail
+
+;; Introduces syntax (lcons a:any b:any).
+;; Wraps second argument in a thunk.
+(define-syntax (lcons stx)
+  (syntax-case stx ()
+    [(_)       (raise-syntax-error #f "[lcons] Expected two arguments.")]
+    [(_ _)     (raise-syntax-error #f "[lcons] Expected two arguments.")]
+    [(_ hd tl) #'(cons hd (lambda () tl))]))
+
+;; --- dispatch tables
+
+(: try-spec (-> zo Spec))
+(define (try-spec z)
+  (match z
+   [(? compilation-top?) (compilation-top->spec z)]
+   [(? prefix?) (prefix->spec z)]
+   [(? global-bucket?) (global-bucket->spec z)]
+   [(? module-variable?) (module-variable->spec z)]
+   [(? stx?) (stx->spec z)]
+   [(? form?) (form->spec z)]
+   [(? expr?) (expr->spec z)]
+   [(? stx-obj?) (stx-obj->spec z)]
+   [(? wrap?) (wrap->spec z)]
+   [(? module-shift?) (module-shift->spec z)]
+   [(? scope?) (scope->spec z)]
+   [(? multi-scope?) (multi-scope->spec z)]
+   [(? binding?) (binding->spec z)]
+   [(? all-from-module?) (all-from-module->spec z)]
+   [(? provided?) (provided->spec z)]
+   [x (error 'try-spec (format "unknown struct ~e" z))]
+))
+(: form->spec (-> form Spec))
+(define (form->spec z)
+  (match z
+   [(? def-values?) (def-values->spec z)]
+   [(? def-syntaxes?) (def-syntaxes->spec z)]
+   [(? seq-for-syntax?) (seq-for-syntax->spec z)]
+   [(? req?) (req->spec z)]
+   [(? seq?) (seq->spec z)]
+   [(? splice?) (splice->spec z)]
+   [(? inline-variant?) (inline-variant->spec z)]
+   [(? mod?) (mod->spec z)]
+   [(? expr?) (expr->spec z)]
+   [x (error 'form (format "unknown struct ~e" z))]
+))
+(: expr->spec (-> expr Spec))
+(define (expr->spec z)
+  (match z
+   [(? lam?) (lam->spec z)]
+   [(? closure?) (closure->spec z)]
+   [(? case-lam?) (case-lam->spec z)]
+   [(? let-one?) (let-one->spec z)]
+   [(? let-void?) (let-void->spec z)]
+   [(? install-value?) (install-value->spec z)]
+   [(? let-rec?) (let-rec->spec z)]
+   [(? boxenv?) (boxenv->spec z)]
+   [(? localref?) (localref->spec z)]
+   [(? toplevel?) (toplevel->spec z)]
+   [(? topsyntax?) (topsyntax->spec z)]
+   [(? application?) (application->spec z)]
+   [(? branch?) (branch->spec z)]
+   [(? with-cont-mark?) (with-cont-mark->spec z)]
+   [(? beg0?) (beg0->spec z)]
+   [(? varref?) (varref->spec z)]
+   [(? assign?) (assign->spec z)]
+   [(? apply-values?) (apply-values->spec z)]
+   [(? primval?) (primval->spec z)]
+   [x (error 'expr (format "unknown struct ~e" z))]
+))
+(: binding->spec (-> binding Spec))
+(define (binding->spec z)
+  (match z
+   [(? module-binding?) (module-binding->spec z)]
+   [(? decoded-module-binding?) (decoded-module-binding->spec z)]
+   [(? local-binding?) (local-binding->spec z)]
+   [(? free-id=?-binding?) (free-id=?-binding->spec z)]
+   [x 'binding (error (format "unknown struct ~e" z))]
+))
+;; --- private functions
+
+(: compilation-top->spec (-> compilation-top Spec))
+(define
+  (compilation-top->spec z)
+  (list "compilation-top"
+        (lcons "max-let-depth" (number->string     (compilation-top-max-let-depth z)))
+        (lcons "binding-namess" (hash->string        (compilation-top-binding-namess z)))
+        (lcons "prefix"        (prefix->spec      (compilation-top-prefix z)))
+        (lcons "code"          (form-or-any->string (compilation-top-code z)))))
+
+(: prefix->spec (-> prefix Spec))
+(define
+  (prefix->spec z)
+  (: tl->spec (-> (U #f Symbol global-bucket module-variable) String))
+  (define (tl->spec tl)
+    (match tl
+      [(? module-variable?)
+       (format-spec #f (module-variable->spec tl))]
+      [(? global-bucket?)
+       (format-spec #f (global-bucket->spec tl))]
+      [(? symbol?)
+       (symbol->string tl)]
+      [#f "#f"]))
+  (list "prefix"
+        (lcons "num-lifts" (number->string                (prefix-num-lifts z)))
+        (lcons "toplevels" (list->string      tl->spec  (prefix-toplevels z)))
+        (lcons "stxs"      (listof-zo->string stx->spec (for/list : (Listof stx) ([sx (prefix-stxs z)] #:when sx) sx)))
+        (lcons "src-inspector-desc" (symbol->string (prefix-src-inspector-desc z)))))
+
+(: global-bucket->spec (-> global-bucket Spec))
+(define
+  (global-bucket->spec  z)
+  (list "global-bucket"
+        (lcons "name" (symbol->string (global-bucket-name z)))))
+
+(: module-variable->spec (-> module-variable Spec))
+(define
+  (module-variable->spec z)
+  (: constantness->spec (-> (U #f 'constant 'fixed function-shape struct-shape) String))
+  (define (constantness->spec cs)
+    (cond [(symbol? cs)         (symbol->string         cs)]
+          [(function-shape? cs) (function-shape->spec cs)]
+          [(struct-shape? cs)   (struct-shape->spec   cs)]
+          [else          "#f"]))
+  (list "module-variable"
+        (lcons "modidx"       (module-path-index->string (module-variable-modidx z)))
+        (lcons "sym"          (symbol->string            (module-variable-sym z)))
+        (lcons "pos"          (number->string            (module-variable-pos z)))
+        (lcons "phase"        (number->string            (module-variable-phase z)))
+        (lcons "constantness" (constantness->spec      (module-variable-constantness z)))))
+
+(: stx->spec (-> stx Spec))
+(define
+  (stx->spec z)
+  (list "stx"
+        (lcons "content" (stx-obj->spec (stx-content z)))))
+
+(: all-from-module->spec (-> all-from-module Spec))
+(define
+  (all-from-module->spec z)
+  (list "all-from-module"
+        (lcons "path"      (module-path-index->string (all-from-module-path z)))
+        (lcons "phase"     (number-or-f->string (all-from-module-phase z)))
+        (lcons "src-phase" (number-or-f->string (all-from-module-src-phase z)))
+        (lcons "inspector-desc" (symbol->string (all-from-module-inspector-desc z)))
+        (lcons "exceptions" (list->string symbol->string (all-from-module-exceptions z)))
+        (lcons "prefix"    (symbol-or-f->string (all-from-module-prefix z)))))
+
+;; --- form
+
+(: def-values->spec (-> def-values Spec))
+(define
+  (def-values->spec z)
+  (: toplevel-or-symbol->string (-> (U toplevel Symbol) String))
+  (define (toplevel-or-symbol->string tl)
+    (match tl
+      [(? toplevel?)
+       (format-spec #f (toplevel->spec tl))]
+      [(? symbol?)
+       (symbol->string tl)]))
+  (list "def-values"
+        (lcons "ids" (list->string toplevel-or-symbol->string (def-values-ids z)))
+        (lcons "rhs" (let ([rhs (def-values-rhs z)])
+                       (cond [(inline-variant? rhs) (inline-variant->spec rhs)]
+                             [else (expr-seq-any->string rhs)])))))
+
+(: def-syntaxes->spec (-> def-syntaxes Spec))
+(define
+  (def-syntaxes->spec z)
+  (: toplevel-or-symbol->string (-> (U toplevel Symbol) String))
+  (define (toplevel-or-symbol->string tl)
+    (match tl
+      [(? toplevel?)
+       (format-spec #f (toplevel->spec tl))]
+      [(? symbol?)
+       (symbol->string tl)]))
+  (list "def-syntaxes"
+        (lcons "ids"           (list->string toplevel-or-symbol->string (def-syntaxes-ids z)))
+        (lcons "rhs"           (expr-seq-any->string                    (def-syntaxes-rhs z)))
+        (lcons "prefix"        (prefix->spec                            (def-syntaxes-prefix z)))
+        (lcons "max-let-depth" (number->string                          (def-syntaxes-max-let-depth z)))
+        (lcons "dummy"         (toplevel-or-any->string                 (def-syntaxes-dummy z)))))
+
+(: seq-for-syntax->spec (-> seq-for-syntax Spec))
+(define
+  (seq-for-syntax->spec z)
+  (list "seq-for-syntax"
+        (lcons "forms"         (listof-form-or-any->string (seq-for-syntax-forms z)))
+        (lcons "prefix"        (prefix->spec             (seq-for-syntax-prefix z)))
+        (lcons "max-let-depth" (number->string             (seq-for-syntax-max-let-depth z)))
+        (lcons "dummy"         (toplevel-or-any->string    (seq-for-syntax-dummy z)))))
+
+(: req->spec (-> req Spec))
+(define
+  (req->spec z)
+  (list "req"
+        (lcons "reqs"  (stx->spec      (req-reqs z)))
+        (lcons "dummy" (toplevel->spec (req-dummy z)))))
+
+(: seq->spec (-> seq Spec))
+(define
+  (seq->spec z)
+  (list "seq"
+        (lcons "forms" (listof-form-or-any->string (seq-forms z)))))
+
+(: splice->spec (-> splice Spec))
+(define
+  (splice->spec z)
+  (list "splice"
+        (lcons "forms" (listof-form-or-any->string (splice-forms z)))))
+
+(: inline-variant->spec (-> inline-variant Spec))
+(define
+  (inline-variant->spec z)
+  (list "inline-variant"
+        (lcons "direct" (expr->spec (inline-variant-direct z)))
+        (lcons "inline" (expr->spec (inline-variant-inline z)))))
+
+(: mod->spec (-> mod Spec))
+(define
+  (mod->spec z)
+  (: name->spec (-> (U Symbol (Listof Symbol)) String))
+  (define (name->spec nm)
+    (match nm
+      [(? list?)
+       (list->string  symbol->string nm)]
+      [(? symbol?)
+       (symbol->string nm)]))
+  (: unexported->spec (-> (Listof (List Exact-Nonnegative-Integer (Listof Symbol) (Listof Symbol))) String))
+  (define (unexported->spec ux)
+    (: elem->spec (-> (List Exact-Nonnegative-Integer (Listof Symbol) (Listof Symbol)) String))
+    (define (elem->spec e)
+      (format-list
+       #:sep " "
+       (list (number->string              (car e))
+             (list->string symbol->string (cadr e))
+             (list->string symbol->string (caddr e)))))
+    (list->string elem->spec ux))
+  (: lang-info->spec (-> (U #f (Vector Module-Path Symbol Any)) String))
+  (define (lang-info->spec li)
+    (match li
+      [(vector mp sym any)
+        (format-list
+         #:sep " "
+         (list (module-path->spec mp)
+               (symbol->string    sym)
+               (any->string       any)))]
+      [#f "#f"]))
+  (: provides->spec (-> (Listof (List (U Integer #f) (Listof provided) (Listof provided))) String))
+  (define
+    (provides->spec pds)
+    (: elem->spec (-> (List (U Integer #f) (Listof provided) (Listof provided)) String))
+    (define (elem->spec e)
+      (format-list
+       #:sep " "
+       (list (if (number? (car e))
+                 (number->string (car e))
+                 "#f")
+             (listof-zo->string provided->spec (cadr e))
+             (listof-zo->string provided->spec (caddr e)))))
+    (list->string elem->spec pds))
+  (: requires->spec (-> (Listof (Pair (U Integer #f) (Listof Module-Path-Index))) String))
+  (define
+    (requires->spec rqs)
+    (: elem->spec (-> (Pair (U Integer #f) (Listof Module-Path-Index)) String))
+    (define (elem->spec e)
+      (format-list
+       #:sep " "
+       (list (if (number? (car e))
+                 (number->string (car e))
+                 "#f")
+             (list->string module-path-index->string (cdr e)))))
+    (list->string elem->spec rqs))
+  (: syntax-bodies->spec (-> (Listof (Pair Exact-Positive-Integer (Listof (U def-syntaxes seq-for-syntax)))) String))
+  (define
+    (syntax-bodies->spec sbs)
+    (: ds-or-sfs->spec (-> (U def-syntaxes seq-for-syntax) String))
+    (define (ds-or-sfs->spec d)
+      (cond [(def-syntaxes?   d) (format-spec #f (def-syntaxes->spec d))]
+            [(seq-for-syntax? d) (format-spec #f (seq-for-syntax->spec d))]))
+    (: elem->spec (-> (Pair Exact-Positive-Integer (Listof (U def-syntaxes seq-for-syntax))) String))
+    (define (elem->spec e)
+      (format-list
+       #:sep " "
+       (list (number->string                 (car e))
+             (list->string ds-or-sfs->spec (cdr e)))))
+    (list->string elem->spec sbs))
+  (: internal-context->string (-> (U #f #t stx (Vectorof stx)) (U Spec String)))
+  (define (internal-context->string ic)
+    (match ic
+      [(? stx? ic)
+       (stx->spec ic)]
+      [(? vector? ic)
+       (listof-zo->string stx->spec (vector->list ic))]
+      [(? boolean? ic)
+       (boolean->string ic)]))
+  (list "mod"
+        (lcons "name"             (name->spec               (mod-name z)))
+        (lcons "srcname"          (symbol->string             (mod-srcname z)))
+        (lcons "self-modidx"      (module-path-index->string  (mod-self-modidx z)))
+        (lcons "prefix"           (prefix->spec             (mod-prefix z)))
+        (lcons "provides"         (provides->spec       (mod-provides z)))
+        (lcons "requires"         (requires->spec       (mod-requires z)))
+        (lcons "body"             (listof-form-or-any->string (mod-body z)))
+        (lcons "syntax-bodies"    (syntax-bodies->spec  (mod-syntax-bodies z)))
+        (lcons "unexported"       (unexported->spec         (mod-unexported z)))
+        (lcons "max-let-depth"    (number->string             (mod-max-let-depth z)))
+        (lcons "dummy"            (toplevel->spec           (mod-dummy z)))
+        (lcons "lang-info"        (lang-info->spec          (mod-lang-info z)))
+        (lcons "internal-context" (internal-context->string (mod-internal-context z)))
+        (lcons "binding-names"    (format "~a" (mod-binding-names z)))
+        (lcons "flags"            (list->string   symbol->string (mod-flags z)))
+        (lcons "pre-submodules"   (listof-zo->string mod->spec (mod-pre-submodules z)))
+        (lcons "post-submodules"  (listof-zo->string mod->spec (mod-post-submodules z)))))
+
+(: provided->spec (-> provided Spec))
+(define
+  (provided->spec z)
+  (: mpi-or-f->string (-> (U Module-Path-Index #f) String))
+  (define (mpi-or-f->string x)
+    (if (eq? #f x)
+        "#f"
+        (module-path-index->string x)))
+  (list "provided"
+        (lcons "name"      (symbol->string (provided-name z)))
+        (lcons "src"       (mpi-or-f->string (provided-src  z)))
+        (lcons "src-name"  (symbol->string (provided-src-name z)))
+        (lcons "nom-src"   (any->string (provided-nom-src z)))
+        (lcons "src-phase" (number->string (provided-src-phase z)))
+        (lcons "protected?" (boolean->string (provided-protected? z)))))
+
+;; --- expr
+
+;; Helper for `lam` and `case-lam`.
+(: lam-name->spec (-> (U Symbol (Vectorof Any) (List )) String))
+(define (lam-name->spec nm)
+  (match nm
+    [(? vector?)
+     (any->string nm)]
+    [(? empty?)
+     "()"]
+    [(? symbol?)
+     (symbol->string nm)]))
+
+(: lam->spec (-> lam Spec))
+(define
+  (lam->spec z)
+  (: closure-map->spec (-> (Vectorof Exact-Nonnegative-Integer) String))
+  (define (closure-map->spec cm)
+    (list->string number->string (vector->list cm)))
+  (: toplevel-map->spec (-> (U #f (Setof Exact-Nonnegative-Integer)) String))
+  (define (toplevel-map->spec tm)
+    (cond [(eq? #f tm) "#f"]
+          [else (format-list
+                 #:sep " "
+                 (for/list : (Listof String) ([n : Exact-Nonnegative-Integer tm]) (number->string n)))]))
+  (list "lam"
+        (lcons "name"          (lam-name->spec                  (lam-name z)))
+        (lcons "flags"         (list->string symbol->string (lam-flags z)))
+        (lcons "num-params"    (number->string              (lam-num-params z)))
+        (lcons "param-types"   (list->string symbol->string (lam-param-types z)))
+        (lcons "rest?"         (boolean->string             (lam-rest? z)))
+        (lcons "closure-map"   (closure-map->spec           (lam-closure-map z)))
+        (lcons "closure-types" (list->string symbol->string (lam-closure-types z)))
+        (lcons "toplevel-map"  (toplevel-map->spec          (lam-toplevel-map z)))
+        (lcons "max-let-depth" (number->string              (lam-max-let-depth z)))
+        (lcons "body"          (expr-seq-any->string        (lam-body z)))))
+
+(: closure->spec (-> closure Spec))
+(define
+  (closure->spec z)
+  (list "closure"
+        (lcons "code"   (lam->spec    (closure-code z)))
+        (lcons "gen-id" (symbol->string (closure-gen-id z)))))
+
+(: case-lam->spec (-> case-lam Spec))
+(define
+  (case-lam->spec z)
+  (list "case-lam"
+        (lcons "name"    (lam-name->spec              (case-lam-name z)))
+        (lcons "clauses" (list->string (lambda ([x : (U lam closure)]) (format-spec #f (expr->spec x))) (case-lam-clauses z)))))
+
+(: let-one->spec (-> let-one Spec))
+(define
+  (let-one->spec z)
+  (list "let-one"
+        (lcons "rhs"    (expr-seq-any->string (let-one-rhs  z)))
+        (lcons "body"   (expr-seq-any->string (let-one-body z)))
+        (lcons "type"   (symbol-or-f->string  (let-one-type z)))
+        (lcons "unused?" (boolean->string      (let-one-unused? z)))))
+
+(: let-void->spec (-> let-void Spec))
+(define
+  (let-void->spec z)
+  (list "let-void"
+        (lcons "count" (number->string       (let-void-count z)))
+        (lcons "boxes" (boolean->string      (let-void-boxes? z)))
+        (lcons "body"  (expr-seq-any->string (let-void-body z)))))
+
+(: install-value->spec (-> install-value Spec))
+(define
+  (install-value->spec z)
+  (list "install-value"
+        (lcons "count"  (number->string       (install-value-count z)))
+        (lcons "pos"    (number->string       (install-value-pos z)))
+        (lcons "boxes?" (boolean->string      (install-value-boxes? z)))
+        (lcons "rhs"    (expr-seq-any->string (install-value-rhs z)))
+        (lcons "body"   (expr-seq-any->string (install-value-body z)))))
+
+(: let-rec->spec (-> let-rec Spec))
+(define
+  (let-rec->spec z)
+  (list "let-rec"
+        (lcons "procs" (list->string (lambda ([lm : lam]) (format-spec #f (lam->spec lm))) (let-rec-procs z)))
+        (lcons "body"  (expr-seq-any->string          (let-rec-body z)))))
+
+(: boxenv->spec (-> boxenv Spec))
+(define
+  (boxenv->spec z)
+  (list "boxenv"
+        (lcons "pos"  (number->string       (boxenv-pos z)))
+        (lcons "body" (expr-seq-any->string (boxenv-body z)))))
+
+(: localref->spec (-> localref Spec))
+(define
+  (localref->spec z)
+  (list "localref"
+        (lcons "unbox?"        (boolean->string     (localref-unbox? z)))
+        (lcons "pos"           (number->string      (localref-pos z)))
+        (lcons "clear?"        (boolean->string     (localref-clear? z)))
+        (lcons "other-clears?" (boolean->string     (localref-other-clears? z)))
+        (lcons "type"          (symbol-or-f->string (localref-type z)))))
+
+(: toplevel->spec (-> toplevel Spec))
+(define
+  (toplevel->spec z)
+  (list
+        "toplevel"
+        (lcons "depth"  (number->string  (toplevel-depth z)))
+        (lcons "pos"    (number->string  (toplevel-pos z)))
+        (lcons "const?" (boolean->string (toplevel-const? z)))
+        (lcons "ready?" (boolean->string (toplevel-ready? z)))))
+
+(: topsyntax->spec (-> topsyntax Spec))
+(define
+  (topsyntax->spec z)
+  (list "topsyntax"
+        (lcons "depth" (number->string (topsyntax-depth z)))
+        (lcons "pos"   (number->string (topsyntax-pos z)))
+        (lcons "midpt" (number->string (topsyntax-midpt z)))))
+
+(: application->spec (-> application Spec))
+(define
+  (application->spec z)
+  (list "application"
+        (lcons "rator" (expr-seq-any->string              (application-rator z)))
+        (lcons "rands" (list->string expr-seq-any->string (application-rands z)))))
+
+(: branch->spec (-> branch Spec))
+(define
+  (branch->spec z)
+  (list "branch"
+        (lcons "test" (expr-seq-any->string (branch-test z)))
+        (lcons "then" (expr-seq-any->string (branch-then z)))
+        (lcons "else" (expr-seq-any->string (branch-else z)))))
+
+(: with-cont-mark->spec (-> with-cont-mark Spec))
+(define
+  (with-cont-mark->spec z)
+  (list "with-cont-mark"
+        (lcons "key"  (expr-seq-any->string (with-cont-mark-key  z)))
+        (lcons "val"  (expr-seq-any->string (with-cont-mark-val  z)))
+        (lcons "body" (expr-seq-any->string (with-cont-mark-body z)))))
+
+(: beg0->spec (-> beg0 Spec))
+(define
+  (beg0->spec z)
+  (list "beg0"
+        (lcons "seq" (list->string expr-seq-any->string (beg0-seq z)))))
+
+(: varref->spec (-> varref Spec))
+(define
+  (varref->spec z)
+  (list "varref"
+        (lcons "toplevel" (match (varref-toplevel z)
+                            [(? toplevel? tl) (toplevel->spec tl)]
+                            [#t    "#t"]))
+        (lcons "dummy"    (match (varref-dummy z)
+                            [(? toplevel? dm) (toplevel->spec dm)]
+                            [#f "#f"]))))
+
+(: assign->spec (-> assign Spec))
+(define
+  (assign->spec z)
+  (list "assign"
+        (lcons "id"        (toplevel->spec     (assign-id z)))
+        (lcons "rhs"       (expr-seq-any->string (assign-rhs z)))
+        (lcons "undef-ok?" (boolean->string      (assign-undef-ok? z)))))
+
+(: apply-values->spec (-> apply-values Spec))
+(define
+  (apply-values->spec z)
+  (list "apply-values"
+        (lcons "proc"      (expr-seq-any->string (apply-values-proc z)))
+        (lcons "args-expr" (expr-seq-any->string (apply-values-args-expr z)))))
+
+(: primval->spec (-> primval Spec))
+(define
+  (primval->spec z)
+  (list "primval"
+        (lcons "id" (number->string (primval-id z)))))
+
+;; --- stx-obj
+
+(: stx-obj->spec (-> stx-obj Spec))
+(define
+  (stx-obj->spec so)
+  (list "stx-obj"
+        (lcons "datum" (any->string (stx-obj-datum so)))
+        (lcons "wrap" (wrap->spec (stx-obj-wrap so)))
+        (lcons "srcloc" (srcloc->string (stx-obj-srcloc so)))
+        (lcons "props" (hash->string (stx-obj-props so)))
+        (lcons "tamper-status" (symbol->string (stx-obj-tamper-status so)))))
+
+;; --- wrap
+
+(: wrap->spec (-> wrap Spec))
+(define
+  (wrap->spec wp)
+  (: ms->string (-> (List multi-scope (U #f Integer)) String))
+  (define (ms->string ms+id)
+    (format "(~a ~a)" (format-spec #f (multi-scope->spec (car ms+id)))
+                      (number-or-f->string (cadr ms+id))))
+  (list "wrap"
+        (lcons "shifts" (listof-zo->string module-shift->spec (wrap-shifts wp)))
+        (lcons "simple-scopes" (listof-zo->string scope->spec (wrap-simple-scopes wp)))
+        (lcons "multi-scopes" (list->string ms->string (wrap-multi-scopes wp)))))
+
+;; --- misc. syntax
+
+(: module-shift->spec (-> module-shift Spec))
+(define
+  (module-shift->spec ms)
+  (list "module-shift"
+        (lcons "from" (cond [(module-shift-from ms) => module-path-index->string] [else "#f"]))
+        (lcons "to" (cond [(module-shift-to ms) => module-path-index->string] [else "#f"]))
+        (lcons "from-inspector-desc" (symbol-or-f->string (module-shift-from-inspector-desc ms)))
+        (lcons "to-inspector-desc" (symbol-or-f->string (module-shift-to-inspector-desc ms)))))
+
+(: scope->spec (-> scope Spec))
+(define
+  (scope->spec sc)
+  (: sym+scope+binding->string (-> (List Symbol (Listof scope) binding) String))
+  (define (sym+scope+binding->string ssbs)
+    (format "(~a ~a ~a)" (symbol->string (car ssbs))
+                         (listof-zo->string scope->spec (cadr ssbs))
+                         (format-spec #f (binding->spec (caddr ssbs)))))
+  (: scope+all-from-module->string (-> (List (Listof scope) all-from-module) String))
+  (define (scope+all-from-module->string bbs)
+    (format "(~a ~a)" (listof-zo->string scope->spec (car bbs))
+                      (format-spec #f (all-from-module->spec (cadr bbs)))))
+  (list "scope"
+        (lcons "name" (let ([name : (U 'root Integer) (scope-name sc)])
+                        (cond [(eq? 'root name) "root"]
+                              [else (number->string name)])))
+        (lcons "kind" (symbol->string (scope-kind sc)))
+        (lcons "bindings" (list->string sym+scope+binding->string (scope-bindings sc)))
+        (lcons "bulk-bindings" (list->string scope+all-from-module->string (scope-bulk-bindings sc)))
+        (lcons "multi-owner" (cond [(scope-multi-owner sc) => multi-scope->spec]
+                                   [else "#f"]))))
+
+(: multi-scope->spec (-> multi-scope Spec))
+(define
+  (multi-scope->spec ms)
+  (: sc->string (-> (List (U Integer #f) scope) String))
+  (define (sc->string id+scope)
+    (format "(~a ~a)" (number-or-f->string (car id+scope))
+                      (format-spec #f (scope->spec (cadr id+scope)))))
+  (list "multi-scope"
+        (lcons "name" (number->string (multi-scope-name ms)))
+        (lcons "src-name" (any->string (multi-scope-src-name ms)))
+        (lcons "scopes" (list->string sc->string (multi-scope-scopes ms)))))
+
+;; --- binding
+
+(: module-binding->spec (-> module-binding Spec))
+(define
+  (module-binding->spec mb)
+  (list "module-binding"
+        (lcons "encoded" (any->string (module-binding-encoded mb)))))
+
+(: decoded-module-binding->spec (-> decoded-module-binding Spec))
+(define
+  (decoded-module-binding->spec dmb)
+  (list "decoded-module-binding"
+        (lcons "path" (cond [(decoded-module-binding-path dmb) => module-path-index->string] [else "#f"]))
+        (lcons "name" (symbol->string (decoded-module-binding-name dmb)))
+        (lcons "phase" (number->string (decoded-module-binding-phase dmb)))
+        (lcons "nominal-path" (cond [(decoded-module-binding-nominal-path dmb) => module-path-index->string] [else "#f"]))
+        (lcons "nominal-export-name" (symbol->string (decoded-module-binding-nominal-export-name dmb)))
+        (lcons "nominal-phase" (number-or-f->string (decoded-module-binding-nominal-phase dmb)))
+        (lcons "import-phase" (number-or-f->string (decoded-module-binding-import-phase dmb)))
+        (lcons "inspector-desc" (symbol-or-f->string (decoded-module-binding-inspector-desc dmb)))))
+
+(: local-binding->spec (-> local-binding Spec))
+(define
+  (local-binding->spec lb)
+  (list "local-binding"
+        (lcons "name" (symbol->string (local-binding-name lb)))))
+
+(: free-id=?-binding->spec (-> free-id=?-binding Spec))
+(define
+  (free-id=?-binding->spec fib)
+  (list "free-id=?-binding"
+        (lcons "base" (binding->spec (free-id=?-binding-base fib)))
+        (lcons "id" (stx-obj->spec (free-id=?-binding-id fib)))
+        (lcons "phase" (number-or-f->string (free-id=?-binding-phase fib)))))
+
+;; --- Shapes
+
+;; Shapes are not zo structs per se, but they are documented in the
+;; decompile guide and do not seem to have a nice formatting method.
+
+(: function-shape->spec (-> function-shape String))
+(define
+  (function-shape->spec fs)
+  (format-list #:sep " "
+               (list "function-shape"
+                     (format "arity : ~a"            (function-shape-arity fs))
+                     (format "preserves-marks? : ~a" (function-shape-preserves-marks? fs)))))
+
+(: struct-shape->spec (-> struct-shape String))
+(define
+  (struct-shape->spec ss)
+  (cond [(struct-type-shape?  ss) (struct-type-shape->spec  ss)]
+        [(constructor-shape?  ss) (constructor-shape->spec  ss)]
+        [(predicate-shape?    ss) (predicate-shape->spec    ss)]
+        [(accessor-shape?     ss) (accessor-shape->spec     ss)]
+        [(mutator-shape?      ss) (mutator-shape->spec      ss)]
+        [(struct-other-shape? ss) (struct-other-shape->spec ss)]
+        [else (error (format "unknown struct shape ~a" ss))]))
+
+(: struct-type-shape->spec (-> struct-type-shape String))
+(define
+  (struct-type-shape->spec sts)
+  (format-list #:sep " "
+               (list "struct-type-shape"
+                     (format "field-count : ~a" (struct-type-shape-field-count sts)))))
+
+(: constructor-shape->spec (-> constructor-shape String))
+(define
+  (constructor-shape->spec cs)
+  (format-list #:sep " "
+               (list "constructor-shape"
+                     (format "arity : ~a" (constructor-shape-arity cs)))))
+
+(: predicate-shape->spec (-> predicate-shape String))
+(define
+  (predicate-shape->spec ps)
+  (format-list (list "predicate-shape")))
+
+(: accessor-shape->spec (-> accessor-shape String))
+(define
+  (accessor-shape->spec sts)
+  (format-list #:sep " "
+               (list "accessor-shape"
+                     (format "field-count : ~a" (accessor-shape-field-count sts)))))
+
+(: mutator-shape->spec (-> mutator-shape String))
+(define
+  (mutator-shape->spec sts)
+  (format-list #:sep " "
+               (list "mutator-shape"
+                     (format "field-count : ~a" (mutator-shape-field-count sts)))))
+
+(: struct-other-shape->spec (-> struct-other-shape String))
+(define
+  (struct-other-shape->spec ps)
+  (format-list (list "struct-other-shape")))
+
+;; --- helpers
+
+;; Turn any value into a string.
+(: any->string (-> Any String))
+(define
+  (any->string z)
+  (format "~a" z))
+
+;; Turn a boolean value into a string.
+(: boolean->string (-> Boolean String))
+(define
+  (boolean->string b)
+  (any->string b))
+
+;; Turn an 'expr' struct or a 'seq' struct or any other value into a string.
+(: expr-seq-any->string (-> (U expr seq Any) String))
+(define
+  (expr-seq-any->string z)
+  (cond [(expr? z) (format-spec #f (expr->spec z))]
+        [(seq?  z) (format-spec #f (seq->spec z))]
+        [else      (any->string z)]))
+
+;; Turn a 'form' struct or anything else into a string.
+(: form-or-any->string (-> (U form Any) String))
+(define
+  (form-or-any->string fm)
+  (cond [(form? fm) (format-spec #f (form->spec fm))]
+        [else       (any->string   fm)]))
+
+;; Alternate syntax for `string-join` -- the `sep` argument appears as a label
+;; and defaults to a newline character.
+(: format-list (->* ((Listof String)) (#:sep String) String))
+(define
+  (format-list xs #:sep [sep "\n"])
+  (string-join xs sep))
+
+;; Turn a spec into a string.
+;; If `deep?` is false, only format the title (ignore the field names + thunks).
+(: format-spec (-> Boolean Spec String))
+(define
+  (format-spec deep? struct-spec)
+  (: fields (Listof (Pair String (-> (U Spec String)))))
+  (define fields (cdr struct-spec))
+  (: title String)
+  (define title (format "<struct:~a>" (car struct-spec)))
+  (: field-name-lengths (Listof Index))
+  (define field-name-lengths
+    (for/list ([fd fields]) (string-length (car fd))))
+  (: w Nonnegative-Fixnum)
+  (define w ;; width of longest struct field name
+    (if (empty? fields) 0 (apply max field-name-lengths)))
+  (if (not deep?)
+      title
+      (format-list
+       (cons title
+             (for/list : (Listof String) ([fd : (Pair String (-> (U Spec String))) fields])
+               (: forced (U String Spec))
+               (define forced ((cdr fd)))
+               (: rest String)
+               (define rest   (if (string? forced)
+                                  forced
+                                  (format-spec #f forced)))
+               (format "  ~a : ~a" (pad (car fd) w) rest))))))
+
+;; Turn a list into a string.
+(: list->string (All (A) (-> (-> A String) (Listof A) String)))
+(define
+  (list->string f xs)
+  (format "[~a]"
+          (format-list #:sep " "
+                       (for/list : (Listof String) ([x : A xs]) (f x)))))
+
+;; Turn a list of things that might be 'form' structs into a list of strings.
+(: listof-form-or-any->string (-> (Listof (U form Any)) String))
+(define
+  (listof-form-or-any->string xs)
+  (list->string form-or-any->string xs))
+
+;; Turn a list of zo structs into a list of strings using the helper function
+;; `z->spec`.
+;; TODO should not be polymorphic -- want to bind to subtypes
+(: listof-zo->string (All (A) (-> (-> A Spec) (Listof A) String)))
+(define
+  (listof-zo->string z->spec zs)
+  (cond [(empty? zs) "[]"]
+        [else        (format "~a[~a]" (format-spec #f (z->spec (car zs))) (length zs))]))
+
+;; Turn a module-path-index into a string
+;; TODO I think we can do better than ~a
+;; http://docs.racket-lang.org/reference/Module_Names_and_Loading.html
+(: module-path-index->string (-> Module-Path-Index String))
+(define
+  (module-path-index->string mpi)
+  (any->string mpi))
+
+;; Turn a module path into a string
+;; TODO can probably improve on ~a
+(: module-path->spec (-> Module-Path String))
+(define
+  (module-path->spec mp)
+  (any->string mp))
+
+;; Turn a number or #f into a string.
+(: number-or-f->string (-> (U Number #f) String))
+(define
+  (number-or-f->string nf)
+  (if (eq? #f nf)
+      "#f"
+      (number->string nf)))
+
+;; Turn a symbol or #f into a string.
+(: symbol-or-f->string (-> (U Symbol #f) String))
+(define
+  (symbol-or-f->string sf)
+  (if (eq? #f sf)
+      "#f"
+      (symbol->string sf)))
+
+(: hash->string (All (A B) (-> (HashTable A B) String)))
+(define
+  (hash->string h)
+  (format "~a" h))
+
+
+;; Turn something that might be a 'toplevel' struct into a string.
+(: toplevel-or-any->string (-> (U toplevel Any) String))
+(define
+  (toplevel-or-any->string tl)
+  (cond [(toplevel? tl) (format-spec #f (toplevel->spec tl))]
+        [else           (any->string tl)]))
+
+;; --- misc
+
+;; If `str` has fewer than `w` characters,
+;; append `(w - (len str))` characters to its right end.
+(: pad (-> String Natural [#:char Char] String))
+(define
+  (pad str w #:char [c #\space])
+  (: l Index)
+  (define l (string-length str))
+  (cond [(< l w) (format "~a~a" str (make-string (- w l) c))]
+        [else    str]))

--- a/typed/private/zo-transition.rkt
+++ b/typed/private/zo-transition.rkt
@@ -1,0 +1,543 @@
+#lang typed/racket/base
+
+;; Access the fields of a struct by name at runtime.
+
+;; Uses predicates to guess what struct its argument is,
+;; then compares strings with statically-known field names.
+;; Functions that end with '->' are the specific transition function
+;; for a type of zo struct.
+
+(provide
+ ;; (-> zo String (values (U zo (Listof zo)) Boolean)))
+ ;; Access "structName-fieldName myStruct" at runtime.
+ zo-transition)
+
+(require racket/match
+         (only-in racket/list empty? empty)
+         zordoz/typed/typed-zo-structs)
+
+;; -----------------------------------------------------------------------------
+
+;; --- API functions
+
+;; Look up the field name `field-name` in the struct `z`.
+;; First use predicates to decide what type of struct `z` is,
+;; then use string equality to check if `field-name` matches any
+;; statically-known name.
+;; Return two values.
+;; - First is a zo struct or list of zo structs, depending on the
+;;   value stored in the field denoted by `field-name`
+;; - Second is a boolean indicating success or failure.
+;;   On failure, the returned zo struct is `z`.
+(: zo-transition (-> zo String (values (U zo (Listof zo)) Boolean)))
+(define (zo-transition z field-name)
+  ;; (-> zo? string? (values (or/c zo? (listof zo?)) boolean?))
+  ;; Check if transition failed or returned a list without any zo, pack result values.
+  (match (try-transition z field-name)
+    [(? zo? nxt)
+     (values nxt #t)]
+    [(? list? nxt)
+     (match (filter zo? nxt)
+       ['() (values z #f)]
+       [zs  (values zs #t)])]
+    [_
+     (values z #f)]))
+
+;; --- dispatch
+(: try-transition (-> zo String (U zo (Listof zo) #f)))
+(define (try-transition z str)
+  (match z
+   [(? compilation-top?) (compilation-top-> z str)]
+   [(? prefix?) (prefix-> z str)]
+   [(? global-bucket?) (global-bucket-> z str)]
+   [(? module-variable?) (module-variable-> z str)]
+   [(? stx?) (stx-> z str)]
+   [(? form?) (form-> z str)]
+   [(? stx-obj?) (stx-obj-> z str)]
+   [(? wrap?) (wrap-> z str)]
+   [(? module-shift?) (module-shift-> z str)]
+   [(? scope?) (scope-> z str)]
+   [(? multi-scope?) (multi-scope-> z str)]
+   [(? binding?) (binding-> z str)]
+   [(? provided?) (provided-> z str)]
+   [(? all-from-module?) (all-from-module-> z str)]
+   [x #f]
+))
+(: form-> (-> zo String (U zo (Listof zo) #f)))
+(define (form-> z str)
+  (match z
+   [(? def-values?) (def-values-> z str)]
+   [(? def-syntaxes?) (def-syntaxes-> z str)]
+   [(? seq-for-syntax?) (seq-for-syntax-> z str)]
+   [(? req?) (req-> z str)]
+   [(? seq?) (seq-> z str)]
+   [(? splice?) (splice-> z str)]
+   [(? inline-variant?) (inline-variant-> z str)]
+   [(? mod?) (mod-> z str)]
+   [(? expr?) (expr-> z str)]
+   [x #f]
+))
+(: expr-> (-> zo String (U zo (Listof zo) #f)))
+(define (expr-> z str)
+  (match z
+   [(? lam?) (lam-> z str)]
+   [(? closure?) (closure-> z str)]
+   [(? case-lam?) (case-lam-> z str)]
+   [(? let-one?) (let-one-> z str)]
+   [(? let-void?) (let-void-> z str)]
+   [(? install-value?) (install-value-> z str)]
+   [(? let-rec?) (let-rec-> z str)]
+   [(? boxenv?) (boxenv-> z str)]
+   [(? localref?) (localref-> z str)]
+   [(? toplevel?) (toplevel-> z str)]
+   [(? topsyntax?) (topsyntax-> z str)]
+   [(? application?) (application-> z str)]
+   [(? branch?) (branch-> z str)]
+   [(? with-cont-mark?) (with-cont-mark-> z str)]
+   [(? beg0?) (beg0-> z str)]
+   [(? varref?) (varref-> z str)]
+   [(? assign?) (assign-> z str)]
+   [(? apply-values?) (apply-values-> z str)]
+   [(? primval?) (primval-> z str)]
+   [x #f]
+))
+(: binding-> (-> binding String (U zo (Listof zo) #f)))
+(define (binding-> z str)
+  (match z
+   [(? module-binding?) (module-binding-> z str)]
+   [(? decoded-module-binding?) (decoded-module-binding-> z str)]
+   [(? local-binding?) (local-binding-> z str)]
+   [(? free-id=?-binding?) (free-id=?-binding-> z str)]
+   [x #f]))
+
+;; --- getters
+(: compilation-top-> (-> compilation-top String (U zo (Listof zo) #f)))
+(define (compilation-top-> z field-name)
+  (match field-name
+    ["prefix"
+     (compilation-top-prefix z)]
+    ["code"
+     (: res (U form Any))
+     (define res (compilation-top-code   z))
+     (if (form? res) res #f)]
+    [_ #f]))
+
+(: prefix-> (-> prefix String (U zo (Listof zo) #f)))
+(define (prefix-> z field-name)
+  (define-predicate gb-or-mv? (U global-bucket module-variable))
+  (match field-name
+    ["toplevels"
+     (filter gb-or-mv? (prefix-toplevels z))]
+    ["stxs"
+     (for/list : (Listof zo) ([sx (prefix-stxs z)] #:when sx) sx)]
+    [_ #f]))
+
+(: global-bucket-> (-> global-bucket String (U zo (Listof zo) #f)))
+(define (global-bucket-> z field-name)
+  #f)
+
+(: module-variable-> (-> module-variable String (U zo (Listof zo) #f)))
+(define (module-variable-> z field-name)
+  #f)
+
+(: stx-> (-> stx String (U zo (Listof zo) #f)))
+(define (stx-> z field-name)
+  (match field-name
+    ["content"
+     (stx-content z)]
+    [_  #f]))
+
+(: all-from-module-> (-> all-from-module String (U zo (Listof zo) #f)))
+(define (all-from-module-> z field-name)
+  #f)
+
+;; --- form
+
+(: def-values-> (-> def-values String (U zo (Listof zo) #f)))
+(define (def-values-> z field-name)
+  (match field-name
+    ["ids"
+     (filter toplevel? (def-values-ids z))]
+    ["rhs"
+     (match (def-values-rhs z)
+       [(or (? expr? rhs) (? seq? rhs) (? inline-variant? rhs))
+        rhs]
+       [_ #f])]
+  [_ #f]))
+
+(: def-syntaxes-> (-> def-syntaxes String (U zo (Listof zo) #f)))
+(define (def-syntaxes-> z field-name)
+  (match field-name
+    ["ids"
+     (filter toplevel? (def-syntaxes-ids z))]
+    ["rhs"
+     (match (def-syntaxes-rhs z)
+       [(or (? expr? rhs) (? seq? rhs)) rhs]
+       [_ #f])]
+    ["prefix"
+     (def-syntaxes-prefix z)]
+    ["dummy"
+     (match (def-syntaxes-dummy z)
+       [(? toplevel? dm) dm]
+       [_ #f])]
+    [_ #f]))
+
+(: seq-for-syntax-> (-> seq-for-syntax String (U zo (Listof zo) #f)))
+(define (seq-for-syntax-> z field-name)
+  (match field-name
+    ["forms"
+     (filter form? (seq-for-syntax-forms z))]
+    ["prefix"
+     (seq-for-syntax-prefix z)]
+    ["dummy"
+     (match (seq-for-syntax-dummy z)
+       [(? toplevel? dm) dm]
+       [_ #f])]
+    [_ #f]))
+
+(: req-> (-> req String (U zo (Listof zo) #f)))
+(define (req-> z field-name)
+  (match field-name
+    ["reqs"
+     (req-reqs z)]
+    ["dummy"
+     (req-dummy z)]
+    [_ #f]))
+
+(: seq-> (-> seq String (U zo (Listof zo) #f)))
+(define (seq-> z field-name)
+  (match field-name
+    ["forms"
+     (filter form? (seq-forms z))]
+    [_ #f]))
+
+(: splice-> (-> splice String (U zo (Listof zo) #f)))
+(define (splice-> z field-name)
+  (match field-name
+    ["forms"
+     (filter form? (splice-forms z))]
+    [_ #f]))
+
+(: inline-variant-> (-> inline-variant String (U zo (Listof zo) #f)))
+(define (inline-variant-> z field-name)
+  (match field-name
+    ["direct"
+     (inline-variant-direct z)]
+    ["inline"
+     (inline-variant-inline z)]
+    [_ #f]))
+
+(: mod-> (-> mod String (U zo (Listof zo) #f)))
+(define (mod-> z field-name)
+  (: get-provided (-> (Listof (List (U Integer #f) (Listof provided) (Listof provided))) (Listof provided)))
+  (define (get-provided pds)
+    (cond [(empty? pds) empty]
+          [else (append (cadar pds)
+                        (caddar pds)
+                        (get-provided (cdr pds)))]))
+  (: get-syntaxes (-> (Listof (Pair Exact-Positive-Integer (Listof (U def-syntaxes seq-for-syntax)))) (Listof (U def-syntaxes seq-for-syntax))))
+  (define (get-syntaxes sxs)
+    (cond [(empty? sxs) empty]
+          [else (append (cdar sxs)
+                        (get-syntaxes (cdr sxs)))]))
+  (match field-name
+    ["prefix"
+     (mod-prefix z)]
+    ["provides"
+     (get-provided (mod-provides z))]
+    ["body"
+     (filter form? (mod-body z))]
+    ["syntax-bodies"
+     (get-syntaxes (mod-syntax-bodies z))]
+    ["dummy"
+     (mod-dummy z)]
+    ["internal-context"
+     (match (mod-internal-context z)
+       [(? stx? ic) ic]
+       [(? vector? ic) (vector->list ic)]
+       [_ #f])]
+    ["pre-submodules"
+     (mod-pre-submodules z)]
+    ["post-submodules"
+     (mod-post-submodules z)]
+    [_ #f]))
+
+(: provided-> (-> provided String (U zo (Listof zo) #f)))
+(define (provided-> z field-name)
+  #f)
+
+;; --- expr
+
+(: lam-> (-> lam String (U zo (Listof zo) #f)))
+(define (lam-> z field-name)
+  (match field-name
+    ["body"
+     (match (lam-body z)
+       [(? expr-or-seq? bd) bd]
+       [_x #f])]
+    [_ #f]))
+
+(: closure-> (-> closure String (U zo (Listof zo) #f)))
+(define (closure-> z field-name)
+  (match field-name
+    ["code"
+     (closure-code z)]
+    [_ #f]))
+
+(: case-lam-> (-> case-lam String (U zo (Listof zo) #f)))
+(define (case-lam-> z field-name)
+  (match field-name
+    ["clauses"
+     (case-lam-clauses z)]
+    [_ #f]))
+
+(: let-one-> (-> let-one String (U zo (Listof zo) #f)))
+(define (let-one-> z field-name)
+  (match field-name
+    ["rhs"
+     (match (let-one-rhs z)
+       [(? expr-or-seq? rhs) rhs]
+       [_ #f])]
+    ["body"
+     (match (let-one-body z)
+       [(? expr-or-seq? body) body]
+       [_ #f])]
+    [_ #f]))
+
+(: let-void-> (-> let-void String (U zo (Listof zo) #f)))
+(define (let-void-> z field-name)
+  (match field-name
+    ["body"
+     (match (let-void-body z)
+       [(? expr-or-seq? body) body]
+       [_ #f])]
+    [_ #f]))
+
+(: install-value-> (-> install-value String (U zo (Listof zo) #f)))
+(define (install-value-> z field-name)
+  (match field-name
+    ["rhs"
+     (match (install-value-rhs z)
+       [(? expr-or-seq? rhs) rhs]
+       [_ #f])]
+    ["body"
+     (match (install-value-body z)
+       [(? expr-or-seq? body) body]
+       [_ #f])]
+    [_ #f]))
+
+(: let-rec-> (-> let-rec String (U zo (Listof zo) #f)))
+(define (let-rec-> z field-name)
+  (match field-name
+    ["procs"
+     (let-rec-procs z)]
+    ["body"
+     (match (let-rec-body z)
+       [(? expr-or-seq? body) body]
+       [_ #f])]
+    [_ #f]))
+
+(: boxenv-> (-> boxenv String (U zo (Listof zo) #f)))
+(define (boxenv-> z field-name)
+  (match field-name
+    ["body"
+     (match (boxenv-body z)
+       [(? expr-or-seq? body) body]
+       [_ #f])]
+    [_ #f]))
+
+(: localref-> (-> localref String (U zo (Listof zo) #f)))
+(define (localref-> z field-name)
+  #f)
+
+(: toplevel-> (-> toplevel String (U zo (Listof zo) #f)))
+(define (toplevel-> z field-name)
+  #f)
+
+(: topsyntax-> (-> topsyntax String (U zo (Listof zo) #f)))
+(define (topsyntax-> z field-name)
+  #f)
+
+(: application-> (-> application String (U zo (Listof zo) #f)))
+(define (application-> z field-name)
+  (match field-name
+    ["rator"
+     (match (application-rator z)
+       [(? expr-or-seq? rator) rator]
+       [_ #f])]
+    ["rands"
+     (filter expr-or-seq? (application-rands z))]
+    [_ #f]))
+
+(: branch-> (-> branch String (U zo (Listof zo) #f)))
+(define (branch-> z field-name)
+  (match field-name
+    ["test"
+     (match (branch-test z)
+       [(? expr-or-seq? test) test]
+       [_ #f])]
+    ["then"
+     (match (branch-then z)
+       [(? expr-or-seq? then) then]
+       [_ #f])]
+    ["else"
+     (match (branch-else z)
+       [(? expr-or-seq? el) el]
+       [_ #f])]
+    [_ #f]))
+
+(: with-cont-mark-> (-> with-cont-mark String (U zo (Listof zo) #f)))
+(define (with-cont-mark-> z field-name)
+  (match field-name
+    ["key"
+     (match (with-cont-mark-key z)
+       [(? expr-or-seq? key)  key]
+       [_ #f])]
+    ["val"
+     (match (with-cont-mark-val z)
+       [(? expr-or-seq? val) val]
+       [_ #f])]
+    ["body"
+     (match (with-cont-mark-body z)
+       [(? expr-or-seq? body) body]
+       [_ #f])]
+    [_ #f]))
+
+(: beg0-> (-> beg0 String (U zo (Listof zo) #f)))
+(define (beg0-> z field-name)
+  (match field-name
+    ["seq" (filter expr-or-seq? (beg0-seq z))]
+    [_ #f]))
+
+(: varref-> (-> varref String (U zo (Listof zo) #f)))
+(define (varref-> z field-name)
+  (match field-name
+    ["toplevel"
+     (match (varref-toplevel z)
+       [(? toplevel? tl) tl]
+       [_ #f])]
+    ["dummy"
+     (match (varref-dummy z)
+       [(? toplevel? dm) dm]
+       [_ #f])]
+    [_ #f]))
+
+(: assign-> (-> assign String (U zo (Listof zo) #f)))
+(define (assign-> z field-name)
+  (match field-name
+    ["id" (assign-id z)]
+    ["rhs" (match (assign-rhs z)
+             [(? expr-or-seq? rhs) rhs]
+             [_ #f])]
+    [_ #f]))
+
+(: apply-values-> (-> apply-values String (U zo (Listof zo) #f)))
+(define (apply-values-> z field-name)
+  (match field-name
+    ["proc"
+     (match (apply-values-proc z)
+       [(? expr-or-seq? proc) proc]
+       [_ #f])]
+    ["args-expr"
+     (match (apply-values-args-expr z)
+       [(? expr-or-seq? args-expr) args-expr]
+       [_ #f])]
+    [_ #f]))
+
+(: primval-> (-> primval String (U zo (Listof zo) #f)))
+(define (primval-> z field-name)
+  #f)
+
+;; --- stx-obj
+
+(: stx-obj-> (-> stx-obj String (U zo (Listof zo) #f)))
+(define
+  (stx-obj-> z field-name)
+  (match field-name
+    ["wrap"
+     (stx-obj-wrap z)]
+    [_ #f]))
+
+;; --- wrap
+
+(: wrap-> (-> wrap String (U zo (Listof zo) #f)))
+(define
+  (wrap-> z field-name)
+  (match field-name
+    ["shifts"
+     (wrap-shifts z)]
+    ["simple-scopes"
+     (wrap-simple-scopes z)]
+    ["multi-scopes"
+     (for/list : (Listof zo) ([ms : (List multi-scope (U #f Integer)) (wrap-multi-scopes z)])
+       (car ms))]
+    [_ #f]))
+
+;; --- misc. syntax
+
+(: module-shift-> (-> module-shift String (U zo (Listof zo) #f)))
+(define
+  (module-shift-> z field-name)
+  (match field-name
+    [_ #f]))
+
+(: scope-> (-> scope String (U zo (Listof zo) #f)))
+(define
+  (scope-> z field-name)
+  (: get-bindings (-> (Listof (List Symbol (Listof scope) binding)) (Listof zo)))
+  (define (get-bindings bs)
+    (cond [(empty? bs) '()]
+          [else (append (cadar bs) (cddar bs) (get-bindings (cdr bs)))]))
+  (: get-bulk-bindings (-> (Listof (List (Listof scope) all-from-module)) (Listof zo)))
+  (define (get-bulk-bindings bbs)
+    (cond [(empty? bbs) '()]
+          [else (append (caar bbs) (cdar bbs) (get-bulk-bindings (cdr bbs)))]))
+  (match field-name
+    ["bindings"
+     (get-bindings (scope-bindings z))]
+    ["bulk-bindings"
+     (get-bulk-bindings (scope-bulk-bindings z))]
+    ["multi-owner"
+     (scope-multi-owner z)]
+    [_ #f]))
+
+(: multi-scope-> (-> multi-scope String (U zo (Listof zo) #f)))
+(define
+  (multi-scope-> z field-name)
+  (match field-name
+    ["scopes"
+     (for/list : (Listof zo) ([mss : (List (U #f Integer) scope) (multi-scope-scopes z)])
+       (cadr mss))]
+    [_ #f]))
+
+(: module-binding-> (-> module-binding  String (U zo (Listof zo) #f)))
+(define
+  (module-binding-> z field-name)
+  (match field-name
+    [_ #f]))
+
+(: decoded-module-binding-> (-> decoded-module-binding String (U zo (Listof zo) #f)))
+(define
+  (decoded-module-binding-> z field-name)
+  (match field-name
+    [_ #f]))
+
+(: local-binding-> (-> local-binding String (U zo (Listof zo) #f)))
+(define
+  (local-binding-> z field-name)
+  #f)
+
+(: free-id=?-binding-> (-> free-id=?-binding String (U zo (Listof zo) #f)))
+(define
+  (free-id=?-binding-> z field-name)
+  (match field-name
+    ["base"
+     (free-id=?-binding-base z)]
+    ["id"
+     (free-id=?-binding-id z)]
+    [_ #f]))
+
+;; --- helpers
+
+;; True if the argument is an 'expr' or a 'seq' zo struct.
+(define-predicate expr-or-seq? (U expr seq))

--- a/typed/typed-zo-structs.rkt
+++ b/typed/typed-zo-structs.rkt
@@ -1,0 +1,227 @@
+#lang typed/racket
+
+
+;; A Spec is the name of a zo struct and a list of pairs representing its fields:
+;; - The car of each field is the name of that field
+;; - The cdr of each field is a thunk for building a representation of the field's value.
+;;   If the value is a zo-struct, the thunk should build a Spec
+;;   Otherwise, the thunk should build a string
+(define-type Spec
+  (Rec Spec
+   (Pair String (Listof (Pair String (-> (U Spec String)))))))
+(provide Spec)
+
+(require/typed/provide compiler/zo-structs
+               [#:struct zo ()]
+               [#:struct (compilation-top zo) (
+                 [max-let-depth : Exact-Nonnegative-Integer]
+                 [binding-namess : (HashTable Exact-Nonnegative-Integer
+                                              (HashTable Symbol Identifier))]
+                 [prefix : prefix]
+                 [code : (U form Any)])]
+               [#:struct (prefix zo) (
+                 [num-lifts : Exact-Nonnegative-Integer] 
+                 [toplevels : (Listof (U #f Symbol global-bucket module-variable))] 
+                 [src-inspector-desc : Symbol]
+                 [stxs : (Listof (U #f stx))])]
+               [#:struct (global-bucket zo) ([name : Symbol])]
+               [#:struct (module-variable zo) (
+                 [modidx : Module-Path-Index] 
+                 [sym : Symbol] 
+                 [pos : Integer] 
+                 [phase : Exact-Nonnegative-Integer]
+                 [constantness : (U #f 'constant 'fixed 
+                                     function-shape
+                                     struct-shape)])]
+               [#:struct function-shape (
+                 [arity : (U Natural arity-at-least (Listof (U Natural arity-at-least)))]
+                 [preserves-marks? : Boolean])] ;; bennn: got type from (:print-type procedure-arity)
+               [#:struct struct-shape ()]
+               [#:struct (struct-type-shape struct-shape) ([field-count : Exact-Nonnegative-Integer])]
+               [#:struct (constructor-shape struct-shape) ([arity : Exact-Nonnegative-Integer])]
+               [#:struct (predicate-shape struct-shape) ()]
+               [#:struct (accessor-shape struct-shape) ([field-count : Exact-Nonnegative-Integer])]
+               [#:struct (mutator-shape struct-shape) ([field-count : Exact-Nonnegative-Integer])]
+               [#:struct (struct-other-shape struct-shape) ()]
+               [#:struct (stx zo) ([content : stx-obj])]
+               [#:struct (stx-obj zo) (
+                 [datum : Any]
+                 [wrap : wrap]
+                 [srcloc : (U #f srcloc)]
+                 [props : (HashTable Symbol Any)]
+                 [tamper-status : (U 'clean 'armed 'tainted)])]
+               [#:struct (form zo) ()]
+               [#:struct (expr form) ()]
+               [#:struct (binding zo) ()]
+               [#:struct (wrap zo) (
+                 [shifts : (Listof module-shift)]
+                 [simple-scopes : (Listof scope)]
+                 [multi-scopes : (Listof (List multi-scope (U #f Integer)))])]
+               [#:struct (all-from-module zo) (
+                 [path : Module-Path-Index]
+                 [phase : (U Integer #f)]
+                 [src-phase : (U Integer #f)]
+                 [inspector-desc : Symbol]
+                 [exceptions : (Listof Symbol)]
+                 [prefix : (U Symbol #f)])]
+               [#:struct (def-values form) (
+                 [ids : (Listof (U toplevel Symbol))]
+                 [rhs : (U expr seq inline-variant Any)])]
+               [#:struct (def-syntaxes form) (
+                 [ids : (Listof (U toplevel Symbol))]
+                 [rhs : (U expr seq Any)] 
+                 [prefix : prefix] 
+                 [max-let-depth : Exact-Nonnegative-Integer]
+                 [dummy : (U toplevel #f)])]
+               [#:struct (seq-for-syntax form) (
+                 [forms : (Listof (U form Any))] ; `begin-for-syntax'
+                 [prefix : prefix] 
+                 [max-let-depth : Exact-Nonnegative-Integer]
+                 [dummy : (U toplevel #f)])]
+               [#:struct (req form) (
+                 [reqs : stx]
+                 [dummy : toplevel])]
+               [#:struct (seq form) (
+                 [forms : (Listof (U form Any))])]
+               [#:struct (splice form) ([forms : (Listof (U form Any))])]
+               [#:struct (inline-variant form) (
+                 [direct : expr]
+                 [inline : expr])]
+               [#:struct (mod form) (
+                 [name : (U Symbol (Listof Symbol))]
+                 [srcname : Symbol]
+                 [self-modidx : Module-Path-Index] 
+                 [prefix : prefix] 
+                 [provides : (Listof (List (U Integer #f)
+                                           (Listof provided)
+                                           (Listof provided)))] 
+                 [requires : (Listof (Pair (U Integer #f)
+                                           (Listof Module-Path-Index)))]
+                 [body : (Listof (U form Any))]
+                 [syntax-bodies : (Listof (Pair Exact-Positive-Integer
+                                                (Listof (U def-syntaxes seq-for-syntax))))]
+                 [unexported : (Listof (List Exact-Nonnegative-Integer
+                                             (Listof Symbol)
+                                             (Listof Symbol)))]
+                 [max-let-depth : Exact-Nonnegative-Integer]
+                 [dummy : toplevel]
+                 [lang-info : (U #f (Vector Module-Path Symbol Any))]
+                 [internal-context : (U #f #t stx (Vectorof stx))]
+                 [binding-names : (HashTable Integer (HashTable Symbol (U #t stx)))]
+                 [flags : (Listof (U 'cross-phase))]
+                 [pre-submodules : (Listof mod)]
+                 [post-submodules : (Listof mod)])]
+               [#:struct (provided zo) (
+                 [name : Symbol] 
+                 [src : (U Module-Path-Index #f)] 
+                 [src-name : Symbol] 
+                 [nom-src : (U Module-Path-Index #f)]
+                 [src-phase : Exact-Nonnegative-Integer] 
+                 [protected? : Boolean])]
+               [#:struct (lam expr) (
+                 [name : (U Symbol (Vectorof Any) (List ))] ;empty list
+                 [flags : (Listof (U 'preserves-marks 'is-method 'single-result
+                                      'only-rest-arg-not-used 'sfs-clear-rest-args))]
+                 [num-params : Exact-Nonnegative-Integer]
+                 [param-types : (Listof (U 'val 'ref 'flonum 'fixnum 'extflonum))]
+                 [rest? : Boolean]
+                 [closure-map : (Vectorof Exact-Nonnegative-Integer)]
+                 [closure-types : (Listof (U 'val/ref 'flonum 'fixnum 'extflonum))]
+                 [toplevel-map : (U #f (Setof Exact-Nonnegative-Integer))]
+                 [max-let-depth : Exact-Nonnegative-Integer]
+                 [body : (U expr seq Any)])]
+               [#:struct (closure expr) (
+                 [code : lam]
+                 [gen-id : Symbol])]
+               [#:struct (case-lam expr) (
+                 [name : (U Symbol (Vectorof Any) (List ))]
+                 [clauses : (Listof (U lam closure))])]
+               [#:struct (let-one expr) (
+                 [rhs : (U expr seq Any)]  ; pushes one value onto stack
+                 [body : (U expr seq Any)] 
+                 [type : (U #f 'flonum 'fixnum 'extflonum)]
+                 [unused? : Boolean])]
+               [#:struct (let-void expr) (
+                 [count : Exact-Nonnegative-Integer]
+                 [boxes? : Boolean]
+                 [body : (U expr seq Any)])]
+               [#:struct (install-value expr) (
+                 [count : Exact-Nonnegative-Integer]
+                 [pos : Exact-Nonnegative-Integer] 
+                 [boxes? : Boolean] 
+                 [rhs : (U expr seq Any)] 
+                 [body : (U expr seq Any)])]
+               [#:struct (let-rec expr) (
+                 [procs : (Listof lam)]
+                 [body : (U expr seq Any)])]
+               [#:struct (boxenv expr) (
+                 [pos : Exact-Nonnegative-Integer]
+                 [body : (U expr seq Any)])]
+               [#:struct (localref expr) (
+                 [unbox? : Boolean] 
+                 [pos : Exact-Nonnegative-Integer] 
+                 [clear? : Boolean] 
+                 [other-clears? : Boolean] 
+                 [type : (U #f 'flonum 'fixnum 'extflonum)])]
+               [#:struct (toplevel expr) (
+                 [depth : Exact-Nonnegative-Integer] 
+                 [pos : Exact-Nonnegative-Integer] 
+                 [const? : Boolean] 
+                 [ready? : Boolean])]
+               [#:struct (topsyntax expr) (
+                 [depth : Exact-Nonnegative-Integer]
+                 [pos : Exact-Nonnegative-Integer]
+                 [midpt : Exact-Nonnegative-Integer])]
+               [#:struct (application expr) (
+                 [rator : (U expr seq Any)]
+                 [rands : (Listof (U expr seq Any))])]
+               [#:struct (branch expr) (
+                 [test : (U expr seq Any)]
+                 [then : (U expr seq Any)]
+                 [else : (U expr seq Any)])]
+               [#:struct (with-cont-mark expr) (
+                 [key : (U expr seq Any)] 
+                 [val : (U expr seq Any)] 
+                 [body : (U expr seq Any)])]
+               [#:struct (beg0 expr) ([seq : (Listof (U expr seq Any))])]
+               [#:struct (varref expr) (
+                 [toplevel : (U toplevel #t)]
+                 [dummy : (U toplevel #f)])]
+               [#:struct (assign expr) (
+                 [id : toplevel]
+                 [rhs : (U expr seq Any)]
+                 [undef-ok? : Boolean])]
+               [#:struct (apply-values expr) (
+                 [proc : (U expr seq Any)]
+                 [args-expr : (U expr seq Any)])]
+               [#:struct (primval expr) ([id : Exact-Nonnegative-Integer])]
+               [#:struct (module-shift zo) (
+                 [from : (U #f Module-Path-Index)]
+                 [to : (U #f Module-Path-Index)]
+                 [from-inspector-desc : (U #f Symbol)]
+                 [to-inspector-desc : (U #f Symbol)])]
+               [#:struct (scope zo) (
+                 [name : (U 'root Natural)]
+                 [kind : Symbol]
+                 [bindings : (Listof (List Symbol (Listof scope) binding))]
+                 [bulk-bindings : (Listof (List (Listof scope) all-from-module))]
+                 [multi-owner : (U #f multi-scope)])]
+               [#:struct (multi-scope zo) (
+                 [name : Natural]
+                 [src-name : Any]
+                 [scopes : (Listof (List (U #f Integer) scope))])]
+               [#:struct (module-binding binding) ([encoded : Any])]
+               [#:struct (decoded-module-binding binding) (
+                 [path : (U #f Module-Path-Index)]
+                 [name : Symbol]
+                 [phase : Integer]
+                 [nominal-path : (U #f Module-Path-Index)]
+                 [nominal-export-name : Symbol]
+                 [nominal-phase : (U #f Integer)]
+                 [import-phase : (U #f Integer)]
+                 [inspector-desc : (U #f Symbol)])]
+               [#:struct (local-binding binding) ([name : Symbol])]
+               [#:struct (free-id=?-binding binding) ([base : binding]
+                 [id : stx-obj]
+                 [phase : (U #f Integer)])]
+               )

--- a/zordoz.rkt
+++ b/zordoz.rkt
@@ -4,17 +4,19 @@
 
 (module+ main
   (require racket/cmdline
-           (only-in zordoz/private/zo-shell filename->shell find-all print-usage))
+           (prefix-in u: zordoz/private/zo-shell)
+           (prefix-in t: zordoz/typed/private/zo-shell))
   ;; -- parameters
   (define search-limit (make-parameter #f))
   (define start-repl? (make-parameter #t))
+  (define typed? (make-parameter #f))
   (define to-find (make-parameter '()))
   ;; -- helpers
   (define (assert-zo filename)
     (define offset (- (string-length filename) 3))
     (or (and (positive? offset)
              (equal? ".zo" (substring filename offset)))
-        (and (print-usage)
+        (and (u:print-usage)
              #f)))
   ;; -- commandline
   (command-line
@@ -31,8 +33,13 @@
     l
     "Maximum depth to search during --find queries"
     (search-limit l)]
+   [("-t" "--typed")
+    "Use typed racket version (disclaimer: types slow this program down)"
+    (typed? #t)]
    #:args (filename)
    (when (assert-zo filename)
+     (define filename->shell (if (typed?) t:filename->shell u:filename->shell))
+     (define find-all (if (typed?) t:find-all u:find-all))
      (if (start-repl?)
          (filename->shell filename)
          (find-all filename (to-find) #:limit (search-limit)))))


### PR DESCRIPTION
Typed racket implementation. The most useful file is `typed-zo-structs.rkt` -- a good cross reference for the zo-lib implementation & docs.