### PR TITLE
Fix primval test

### DIFF
--- a/main.rkt
+++ b/main.rkt
@@ -40,7 +40,7 @@
           [syntax->shell (-> syntax? void?)]
           ;; Start a REPL session to explore a syntax object
 
-          [compiled->zo (-> compiled-expression? zo?)]
+          [compiled-expression->zo (-> compiled-expression? zo?)]
           ;; Convert a compiled expression into a zo struct
 
           [syntax->zo (-> syntax? zo?)]

--- a/private/zo-syntax.rkt
+++ b/private/zo-syntax.rkt
@@ -7,7 +7,7 @@
 
 (provide
 
-  compiled->zo
+  compiled-expression->zo
   ;; (-> Compiled-Expression compilation-top)
   ;; Turn a compiled expression into a zo struct
 
@@ -34,7 +34,7 @@
 
 ;; =============================================================================
 
-(define (compiled->zo compiled)
+(define (compiled-expression->zo compiled)
   (define-values (in out) (make-pipe))
   (display compiled out)
   (close-output-port out)
@@ -43,7 +43,7 @@
   (zo-parse (open-input-bytes y)))
 
 (define (syntax->zo stx)
-  (compiled->zo (compile-syntax (expand-syntax-top-level-with-compile-time-evals stx))))
+  (compiled-expression->zo (compile-syntax (expand-syntax-top-level-with-compile-time-evals stx))))
 
 (define (syntax->decompile stx)
   (decompile (syntax->zo stx)))

--- a/private/zo-syntax.rkt
+++ b/private/zo-syntax.rkt
@@ -78,7 +78,7 @@
     (check-true (application? rhs))
     (define rator (application-rator rhs))
     (check-true (primval? rator))
-    (check-equal? (primval-id rator) 129)
+    (check-pred integer? (primval-id rator))
     (check-equal? (application-rands rhs) '(a))
     ;; --- body
     (define body (let-one-body l))
@@ -103,7 +103,8 @@
     (check-equal? (eval c) 666))
 
   (let* ([p (prefix 9 '() '() 'wepa)]
-         [z (compilation-top 0 (hash) p (primval 129))]
+         [box-id (primval-id (compilation-top-code (syntax->zo #'box)))]
+         [z (compilation-top 0 (hash) p (primval box-id))]
          [c (zo->compiled-expression z)])
     (check-equal? (eval c) box))
 )

--- a/private/zo-syntax.rkt
+++ b/private/zo-syntax.rkt
@@ -61,6 +61,12 @@
 (module+ test
   (require rackunit)
 
+  ;; -- compiled-expression->zo
+  (let* ([e (compile-syntax #'(box 3))]
+         [z (compiled-expression->zo e)])
+    (check-pred compilation-top? z)
+    (check-pred application? (compilation-top-code z)))
+
   ;; -- syntax->zo
   (let* ([stx #'(+ 1 3)]
          [z (syntax->zo stx)])

--- a/scribblings/api.scrbl
+++ b/scribblings/api.scrbl
@@ -159,7 +159,7 @@ Tools for compiling syntax fragments rather than entire modules.
   (syntax->decompile #'(if #t 'left 'right))
 ]
 
-@defproc[(compiled->zo [cmp compiled-expression?]) zo?]{
+@defproc[(compiled-expression->zo [cmp compiled-expression?]) zo?]{
   Converts a compiled expression into a zo struct.
   Differs from @racket[zo-parse] in that the input is expected to be a
   @racket[compiled-expression?].
@@ -167,9 +167,9 @@ Tools for compiling syntax fragments rather than entire modules.
 }
 
 @examples[#:eval zordoz-eval
-  (compiled->zo (compile-syntax #'6))
-  (compiled->zo (compile-syntax #'(member 'a '(a b c))))
-  (compiled->zo (compile-syntax #'(if #t 'left 'right)))
+  (compiled-expression->zo (compile-syntax #'6))
+  (compiled-expression->zo (compile-syntax #'(member 'a '(a b c))))
+  (compiled-expression->zo (compile-syntax #'(if #t 'left 'right)))
 ]
 
 @defproc[(zo->compiled-expression [z zo?]) compiled-expression?]{


### PR DESCRIPTION
1. Fixes 2 brittle unit tests
2. Renames `compiled->zo` to `compiled-expression->zo`. @LeifAndersen is this ok? I want this function's name to match the name of `zo->compiled-expression`
3. Adds a small unit test for `compiled->zo`.